### PR TITLE
feat: remove code table

### DIFF
--- a/benches/multihash.rs
+++ b/benches/multihash.rs
@@ -1,7 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::Rng;
 
-use tiny_multihash::{
+use multihash::{
     Blake2b256, Blake2b512, Blake2s128, Blake2s256, Hasher, Keccak224, Keccak256, Keccak384,
     Keccak512, Sha1, Sha2_256, Sha2_512, Sha3_224, Sha3_256, Sha3_384, Sha3_512, Strobe256,
     Strobe512,

--- a/proc-macro/src/multihash.rs
+++ b/proc-macro/src/multihash.rs
@@ -1,6 +1,6 @@
 use crate::utils;
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
+use quote::quote;
 use syn::parse::{Parse, ParseStream};
 use synstructure::{Structure, VariantInfo};
 
@@ -16,7 +16,6 @@ mod kw {
 #[derive(Debug)]
 enum MhAttr {
     Code(utils::Attr<kw::code, syn::LitInt>),
-    Digest(utils::Attr<kw::digest, syn::Path>),
     Hasher(utils::Attr<kw::hasher, syn::Path>),
 }
 
@@ -24,8 +23,6 @@ impl Parse for MhAttr {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         if input.peek(kw::code) {
             Ok(MhAttr::Code(input.parse()?))
-        } else if input.peek(kw::digest) {
-            Ok(MhAttr::Digest(input.parse()?))
         } else {
             Ok(MhAttr::Hasher(input.parse()?))
         }
@@ -34,7 +31,6 @@ impl Parse for MhAttr {
 
 struct Params {
     mh: syn::Ident,
-    mh_code: syn::Ident,
     mh_digest: syn::Ident,
 }
 
@@ -47,15 +43,9 @@ struct Hash {
 }
 
 impl Hash {
-    fn match_arm_u64(&self, tokens: TokenStream) -> TokenStream {
+    fn match_arm_code(&self, tokens: TokenStream) -> TokenStream {
         let code = &self.code;
         quote!(#code => #tokens)
-    }
-
-    fn match_arm_code(&self, params: &Params, tokens: TokenStream) -> TokenStream {
-        let ident = &self.ident;
-        let mh_code = &params.mh_code;
-        quote!(#mh_code::#ident => #tokens)
     }
 
     fn match_arm_digest(&self, params: &Params, tokens: TokenStream) -> TokenStream {
@@ -64,51 +54,30 @@ impl Hash {
         quote!(#mh_digest::#ident(mh) => #tokens)
     }
 
-    fn to_u64(&self, params: &Params) -> TokenStream {
-        let code = &self.code;
-        self.match_arm_code(params, quote!(#code))
-    }
-
-    fn try_from_u64(&self, _params: &Params) -> TokenStream {
-        let ident = &self.ident;
-        self.match_arm_u64(quote!(Ok(Self::#ident)))
-    }
-
-    fn multihash(&self) -> TokenStream {
-        let ident = &self.ident;
-        let digest = &self.digest;
-        quote! {
-            /// Multihash array for hash function.
-            #ident(#digest)
-        }
-    }
-
     fn digest_code(&self, params: &Params) -> TokenStream {
-        let mh_code = &params.mh_code;
-        let ident = &self.ident;
-        self.match_arm_digest(params, quote!(#mh_code::#ident))
+        let code = &self.code;
+        self.match_arm_digest(params, quote!(#code))
+    }
+
+    fn digest_size(&self, params: &Params) -> TokenStream {
+        let hasher = &self.hasher;
+        self.match_arm_digest(params, quote!(#hasher::size()))
     }
 
     fn digest_digest(&self, params: &Params) -> TokenStream {
         self.match_arm_digest(params, quote!(mh.as_ref()))
     }
 
+    fn digest_new(&self) -> TokenStream {
+        let ident = &self.ident;
+        let hasher = &self.hasher;
+        self.match_arm_code(quote!(Ok(Self::#ident(#hasher::digest(input)))))
+    }
+
     fn digest_read(&self, params: &Params) -> TokenStream {
         let ident = &self.ident;
         let mh = &params.mh;
-        self.match_arm_code(params, quote!(Ok(Self::#ident(#mh::read_digest(r)?))))
-    }
-
-    fn code_size(&self, params: &Params) -> TokenStream {
-        let hasher = &self.hasher;
-        self.match_arm_code(params, quote!(#hasher::size()))
-    }
-
-    fn code_digest(&self, params: &Params) -> TokenStream {
-        let mh_digest = &params.mh_digest;
-        let ident = &self.ident;
-        let hasher = &self.hasher;
-        self.match_arm_code(params, quote!(#mh_digest::#ident(#hasher::digest(input))))
+        self.match_arm_code(quote!(Ok(Self::#ident(#mh::read_digest(r)?))))
     }
 
     fn from_digest(&self, params: &Params) -> TokenStream {
@@ -136,12 +105,20 @@ impl<'a> From<&'a VariantInfo<'a>> for Hash {
                 for attr in attr.attrs {
                     match attr {
                         MhAttr::Code(attr) => code = Some(attr.value),
-                        MhAttr::Digest(attr) => digest = Some(attr.value),
                         MhAttr::Hasher(attr) => hasher = Some(attr.value),
                     }
                 }
             }
         }
+
+        if let syn::Fields::Unnamed(syn::FieldsUnnamed { unnamed, .. }) = bi.ast().fields {
+            if let Some(field) = unnamed.first() {
+                if let syn::Type::Path(path) = &field.ty {
+                    digest = Some(path.path.clone());
+                }
+            }
+        }
+
         let ident = bi.ast().ident.clone();
         let code = code.unwrap_or_else(|| {
             let msg = "Missing code attribute: #[mh(code = 0x42)]";
@@ -175,61 +152,51 @@ impl<'a> From<&'a VariantInfo<'a>> for Hash {
 
 pub fn multihash(s: Structure) -> TokenStream {
     let mh = utils::use_crate("multihash");
-    let mh_code = &s.ast().ident;
-    let mh_digest = format_ident!("Multihash");
+    let mh_digest = &s.ast().ident;
     let hashes: Vec<_> = s.variants().iter().map(Hash::from).collect();
     let params = Params {
         mh: mh.clone(),
-        mh_code: mh_code.clone(),
         mh_digest: mh_digest.clone(),
     };
 
-    let to_u64 = hashes.iter().map(|h| h.to_u64(&params));
-    let try_from_u64 = hashes.iter().map(|h| h.try_from_u64(&params));
-    let multihash = hashes.iter().map(|h| h.multihash());
     let digest_code = hashes.iter().map(|h| h.digest_code(&params));
+    let digest_size = hashes.iter().map(|h| h.digest_size(&params));
     let digest_digest = hashes.iter().map(|h| h.digest_digest(&params));
+    let digest_new = hashes.iter().map(|h| h.digest_new());
     let digest_read = hashes.iter().map(|h| h.digest_read(&params));
     let from_digest = hashes.iter().map(|h| h.from_digest(&params));
-    let code_size = hashes.iter().map(|h| h.code_size(&params));
-    let code_digest = hashes.iter().map(|h| h.code_digest(&params));
 
     quote! {
-        impl From<#mh_code> for u64 {
-            fn from(c: #mh_code) -> Self {
-                match c {
-                    #(#to_u64,)*
-                }
+        impl From<#mh_digest> for u64 {
+           fn from(mh: #mh_digest) -> Self {
+               mh.code()
+           }
+        }
+
+        impl #mh::MultihashDigest for #mh_digest {
+            fn code(&self) -> u64 {
+               match self {
+                   #(#digest_code,)*
+               }
             }
-        }
 
-        impl core::convert::TryFrom<u64> for #mh_code {
-            type Error = #mh::Error;
-
-            fn try_from(n: u64) -> Result<Self, Self::Error> {
-                match n {
-                    #(#try_from_u64,)*
-                    _ => Err(Self::Error::UnsupportedCode(n)),
-                }
-            }
-        }
-
-        /// Multihash.
-        #[derive(Clone, Debug, Eq, PartialEq)]
-        pub enum #mh_digest {
-            #(#multihash,)*
-        }
-
-        impl #mh::MultihashDigest<#mh_code> for #mh_digest {
-            fn code(&self) -> #mh_code {
+            fn size(&self) -> u8 {
+                use #mh::Hasher;
                 match self {
-                    #(#digest_code,)*
+                    #(#digest_size,)*
                 }
             }
 
             fn digest(&self) -> &[u8] {
                 match self {
                     #(#digest_digest,)*
+                }
+            }
+
+            fn new(code: u64, input: &[u8]) -> Result<Self, #mh::Error> {
+                match code {
+                    #(#digest_new,)*
+                    _ => Err(#mh::Error::UnsupportedCode(code)),
                 }
             }
 
@@ -241,29 +208,12 @@ pub fn multihash(s: Structure) -> TokenStream {
                 let code = #mh::read_code(&mut r)?;
                 match code {
                     #(#digest_read,)*
+                    _ => Err(#mh::Error::UnsupportedCode(code)),
                 }
             }
         }
 
         #(#from_digest)*
-
-        impl #mh::MultihashCode for #mh_code {
-            type Multihash = #mh_digest;
-
-            fn size(&self) -> u8 {
-                use #mh::Hasher;
-                match self {
-                    #(#code_size,)*
-                }
-            }
-
-            fn digest(&self, input: &[u8]) -> Self::Multihash {
-                use #mh::Hasher;
-                match self {
-                    #(#code_digest,)*
-                }
-            }
-        }
     }
 }
 
@@ -274,60 +224,48 @@ mod tests {
     #[test]
     fn test_multihash_derive() {
         let input = quote! {
-            #[derive(Clone, Copy, Multihash)]
-            pub enum Code {
-                #[mh(code = 0x00, hasher = multihash::Identity256, digest = multihash::IdentityDigest<U32>)]
-                Identity256,
-                #[mh(code = 0x01, hasher = multihash::Strobe256, digest = multihash::StrobeDigest<U32>)]
-                Strobe256,
+           #[derive(Clone, Multihash)]
+           pub enum Multihash {
+               #[mh(code = 0x00, hasher = multihash::Identity256)]
+               Identity256(multihash::IdentityDigest<U32>),
+               /// Multihash array for hash function.
+               #[mh(code = 0x01, hasher = multihash::Strobe256)]
+               Strobe256(multihash::StrobeDigest<U32>),
             }
         };
         let expected = quote! {
-            impl From<Code> for u64 {
-                fn from(c: Code) -> Self {
-                    match c {
-                        Code::Identity256 => 0x00,
-                        Code::Strobe256 => 0x01,
-                    }
+            impl From<Multihash> for u64 {
+                fn from(mh: Multihash) -> Self {
+                    mh.code()
                 }
             }
-
-            impl core::convert::TryFrom<u64> for Code {
-                type Error = multihash::Error;
-
-                fn try_from(n: u64) -> Result<Self, Self::Error> {
-                    match n {
-                        0x00 => Ok(Self::Identity256),
-                        0x01 => Ok(Self::Strobe256),
-                        _ => Err(Self::Error::UnsupportedCode(n)),
-                    }
-                }
-            }
-
-            /// Multihash.
-            #[derive(Clone, Debug, Eq, PartialEq)]
-            pub enum Multihash {
-                /// Multihash array for hash function.
-                Identity256(multihash::IdentityDigest<U32>),
-                /// Multihash array for hash function.
-                Strobe256(multihash::StrobeDigest<U32>),
-            }
-
-            impl multihash::MultihashDigest<Code> for Multihash {
-                fn code(&self) -> Code {
+            impl multihash::MultihashDigest for Multihash {
+                fn code(&self) -> u64 {
                     match self {
-                        Multihash::Identity256(mh) => Code::Identity256,
-                        Multihash::Strobe256(mh) => Code::Strobe256,
+                        Multihash::Identity256(mh) => 0x00,
+                        Multihash::Strobe256(mh) => 0x01,
                     }
                 }
-
+                fn size(&self) -> u8 {
+                    use multihash::Hasher;
+                    match self {
+                        Multihash::Identity256(mh) => multihash::Identity256::size(),
+                        Multihash::Strobe256(mh) => multihash::Strobe256::size(),
+                    }
+                }
                 fn digest(&self) -> &[u8] {
                     match self {
                         Multihash::Identity256(mh) => mh.as_ref(),
                         Multihash::Strobe256(mh) => mh.as_ref(),
                     }
                 }
-
+                fn new(code: u64, input: &[u8]) -> Result<Self, multihash::Error> {
+                    match code {
+                        0x00 => Ok(Self::Identity256(multihash::Identity256::digest(input))),
+                        0x01 => Ok(Self::Strobe256(multihash::Strobe256::digest(input))),
+                        _ => Err(multihash::Error::UnsupportedCode(code)),
+                    }
+                }
                 #[cfg(feature = "std")]
                 fn read<R: std::io::Read>(mut r: R) -> Result<Self, multihash::Error>
                 where
@@ -335,41 +273,20 @@ mod tests {
                 {
                     let code = multihash::read_code(&mut r)?;
                     match code {
-                        Code::Identity256 => Ok(Self::Identity256(multihash::read_digest(r)?)),
-                        Code::Strobe256 => Ok(Self::Strobe256(multihash::read_digest(r)?)),
+                        0x00 => Ok(Self::Identity256(multihash::read_digest(r)?)),
+                        0x01 => Ok(Self::Strobe256(multihash::read_digest(r)?)),
+                        _ => Err(multihash::Error::UnsupportedCode(code)),
                     }
                 }
             }
-
             impl From<multihash::IdentityDigest<U32> > for Multihash {
                 fn from(digest: multihash::IdentityDigest<U32>) -> Self {
                     Self::Identity256(digest)
                 }
             }
-
             impl From<multihash::StrobeDigest<U32> > for Multihash {
                 fn from(digest: multihash::StrobeDigest<U32>) -> Self {
                     Self::Strobe256(digest)
-                }
-            }
-
-            impl multihash::MultihashCode for Code {
-                type Multihash = Multihash;
-
-                fn size(&self) -> u8 {
-                    use multihash::Hasher;
-                    match self {
-                        Code::Identity256 => multihash::Identity256::size(),
-                        Code::Strobe256 => multihash::Strobe256::size(),
-                    }
-                }
-
-                fn digest(&self, input: &[u8]) -> Self::Multihash {
-                    use multihash::Hasher;
-                    match self {
-                        Code::Identity256 => Multihash::Identity256(multihash::Identity256::digest(input)),
-                        Code::Strobe256 => Multihash::Strobe256(multihash::Strobe256::digest(input)),
-                    }
                 }
             }
         };

--- a/proc-macro/src/multihash.rs
+++ b/proc-macro/src/multihash.rs
@@ -118,21 +118,21 @@ impl<'a> From<&'a VariantInfo<'a>> for Hash {
 
         let ident = bi.ast().ident.clone();
         let code = code.unwrap_or_else(|| {
-            let msg = "Missing code attribute: #[mh(code = 0x42)]";
+            let msg = "Missing code attribute: e.g. #[mh(code = 0x42)]";
             #[cfg(test)]
             panic!(msg);
             #[cfg(not(test))]
             proc_macro_error::abort!(ident, msg);
         });
         let hasher = hasher.unwrap_or_else(|| {
-            let msg = "Missing hasher attribute: #[mh(hasher = multihash::Sha2_256)]";
+            let msg = "Missing hasher attribute: e.g. #[mh(hasher = multihash::Sha2_256)]";
             #[cfg(test)]
             panic!(msg);
             #[cfg(not(test))]
             proc_macro_error::abort!(ident, msg);
         });
         let digest = digest.unwrap_or_else(|| {
-            let msg = "Missing digest in enum variant: Sha256(multihash::Sha2Digest<U32>)]";
+            let msg = "Missing digest in enum variant: e.g. Sha256(multihash::Sha2Digest<U32>)]";
             #[cfg(test)]
             panic!(msg);
             #[cfg(not(test))]

--- a/proc-macro/src/multihash.rs
+++ b/proc-macro/src/multihash.rs
@@ -193,13 +193,6 @@ pub fn multihash(s: Structure) -> TokenStream {
                 }
             }
 
-            fn new(code: u64, input: &[u8]) -> Result<Self, #mh::Error> {
-                match code {
-                    #(#digest_new,)*
-                    _ => Err(#mh::Error::UnsupportedCode(code)),
-                }
-            }
-
             #[cfg(feature = "std")]
             fn read<R: std::io::Read>(mut r: R) -> Result<Self, #mh::Error>
             where
@@ -211,6 +204,15 @@ pub fn multihash(s: Structure) -> TokenStream {
                     _ => Err(#mh::Error::UnsupportedCode(code)),
                 }
             }
+        }
+
+        impl #mh::MultihashCreate for #mh_digest {
+           fn new(code: u64, input: &[u8]) -> Result<Self, #mh::Error> {
+              match code {
+                  #(#digest_new,)*
+                  _ => Err(#mh::Error::UnsupportedCode(code)),
+              }
+           }
         }
 
         #(#from_digest)*
@@ -259,13 +261,6 @@ mod tests {
                         Multihash::Strobe256(mh) => mh.as_ref(),
                     }
                 }
-                fn new(code: u64, input: &[u8]) -> Result<Self, multihash::Error> {
-                    match code {
-                        0x00 => Ok(Self::Identity256(multihash::Identity256::digest(input))),
-                        0x01 => Ok(Self::Strobe256(multihash::Strobe256::digest(input))),
-                        _ => Err(multihash::Error::UnsupportedCode(code)),
-                    }
-                }
                 #[cfg(feature = "std")]
                 fn read<R: std::io::Read>(mut r: R) -> Result<Self, multihash::Error>
                 where
@@ -275,6 +270,15 @@ mod tests {
                     match code {
                         0x00 => Ok(Self::Identity256(multihash::read_digest(r)?)),
                         0x01 => Ok(Self::Strobe256(multihash::read_digest(r)?)),
+                        _ => Err(multihash::Error::UnsupportedCode(code)),
+                    }
+                }
+            }
+            impl multihash::MultihashCreate for Multihash {
+                fn new(code: u64, input: &[u8]) -> Result<Self, multihash::Error> {
+                    match code {
+                        0x00 => Ok(Self::Identity256(multihash::Identity256::digest(input))),
+                        0x01 => Ok(Self::Strobe256(multihash::Strobe256::digest(input))),
                         _ => Err(multihash::Error::UnsupportedCode(code)),
                     }
                 }

--- a/src/arb.rs
+++ b/src/arb.rs
@@ -1,47 +1,38 @@
 use quickcheck::{Arbitrary, Gen};
 use rand::seq::SliceRandom;
 
-use crate::code::{Code, Code::*, Multihash};
-use crate::multihash::MultihashCode;
+use crate::code::*;
+use crate::MultihashCreate;
 
-const HASHES: [Code; 16] = [
-    Identity256,
-    Sha1,
-    Sha2_256,
-    Sha2_512,
-    Sha3_512,
-    Sha3_384,
-    Sha3_256,
-    Sha3_224,
-    Keccak224,
-    Keccak256,
-    Keccak384,
-    Keccak512,
-    Blake2b256,
-    Blake2b512,
-    Blake2s128,
-    Blake2s256,
+const HASHES: [u64; 16] = [
+    IDENTITY,
+    SHA1,
+    SHA2_256,
+    SHA2_512,
+    SHA3_512,
+    SHA3_384,
+    SHA3_256,
+    SHA3_224,
+    KECCAK_224,
+    KECCAK_256,
+    KECCAK_384,
+    KECCAK_512,
+    BLAKE2B_256,
+    BLAKE2B_512,
+    BLAKE2S_128,
+    BLAKE2S_256,
 ];
-
-/// Generates a random hash algorithm.
-///
-/// The more exotic ones will be generated just as frequently as the common ones.
-impl Arbitrary for Code {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
-        *HASHES.choose(g).unwrap()
-    }
-}
 
 /// Generates a random valid multihash.
 ///
 /// This is done by encoding a random piece of data.
 impl Arbitrary for Multihash {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
-        let code: Code = Arbitrary::arbitrary(g);
+        let code = *HASHES.choose(g).unwrap();
         let data: Vec<u8> = Arbitrary::arbitrary(g);
         // encoding an actual random piece of data might be better than just choosing
         // random numbers of the appropriate size, since some hash algos might produce
         // a limited set of values
-        code.digest(&data)
+        Multihash::new(code, &data).unwrap()
     }
 }

--- a/src/code.rs
+++ b/src/code.rs
@@ -3,25 +3,44 @@ use crate::hasher::Hasher;
 use crate::multihash::MultihashDigest;
 use multihash_proc_macro::Multihash;
 
+/// Multihash code for Identity.
 pub const IDENTITY: u64 = 0x00;
+/// Multihash code for SHA1.
 pub const SHA1: u64 = 0x11;
+/// Multihash code for SHA2-256.
 pub const SHA2_256: u64 = 0x12;
+/// Multihash code for SHA2-512.
 pub const SHA2_512: u64 = 0x13;
+/// Multihash code for SHA3-224.
 pub const SHA3_224: u64 = 0x17;
+/// Multihash code for SHA3-256.
 pub const SHA3_256: u64 = 0x16;
+/// Multihash code for SHA3-384.
 pub const SHA3_384: u64 = 0x15;
+/// Multihash code for SHA3-512.
 pub const SHA3_512: u64 = 0x14;
+/// Multihash code for KECCAK-224.
 pub const KECCAK_224: u64 = 0x1a;
+/// Multihash code for KECCAK-256.
 pub const KECCAK_256: u64 = 0x1b;
+/// Multihash code for KECCAK-384.
 pub const KECCAK_384: u64 = 0x1c;
+/// Multihash code for KECCAK-512.
 pub const KECCAK_512: u64 = 0x1d;
+/// Multihash code for BLAKE2b-256.
 pub const BLAKE2B_256: u64 = 0xb220;
+/// Multihash code for BLAKE2b-512.
 pub const BLAKE2B_512: u64 = 0xb240;
+/// Multihash code for BLAKE2s-128.
 pub const BLAKE2S_128: u64 = 0xb250;
+/// Multihash code for BLAKE2s-256.
 pub const BLAKE2S_256: u64 = 0xb260;
+/// Multihash code for STROBE-256.
 pub const STROBE_256: u64 = 0xa0;
+/// Multihash code for STROBE-512.
 pub const STROBE_512: u64 = 0xa1;
 
+/// An implementation of Multihash.
 #[derive(Clone, Debug, Eq, Multihash, PartialEq)]
 pub enum Multihash {
     /// Multihash array for hash function.

--- a/src/code.rs
+++ b/src/code.rs
@@ -3,61 +3,80 @@ use crate::hasher::Hasher;
 use crate::multihash::MultihashDigest;
 use multihash_proc_macro::Multihash;
 
+pub const IDENTITY: u64 = 0x00;
+pub const SHA1: u64 = 0x11;
+pub const SHA2_256: u64 = 0x12;
+pub const SHA2_512: u64 = 0x13;
+pub const SHA3_224: u64 = 0x17;
+pub const SHA3_256: u64 = 0x16;
+pub const SHA3_384: u64 = 0x15;
+pub const SHA3_512: u64 = 0x14;
+pub const KECCAK_224: u64 = 0x1a;
+pub const KECCAK_256: u64 = 0x1b;
+pub const KECCAK_384: u64 = 0x1c;
+pub const KECCAK_512: u64 = 0x1d;
+pub const BLAKE2B_256: u64 = 0xb220;
+pub const BLAKE2B_512: u64 = 0xb240;
+pub const BLAKE2S_128: u64 = 0xb250;
+pub const BLAKE2S_256: u64 = 0xb260;
+pub const STROBE_256: u64 = 0xa0;
+pub const STROBE_512: u64 = 0xa1;
+
 #[derive(Clone, Debug, Eq, Multihash, PartialEq)]
 pub enum Multihash {
     /// Multihash array for hash function.
-    #[mh(code = 0x00, hasher = crate::Identity256)]
+    #[mh(code = crate::IDENTITY, hasher = crate::Identity256)]
     Identity256(crate::IdentityDigest<crate::U32>),
     /// Multihash array for hash function.
-    #[mh(code = 0x11, hasher = crate::Sha1)]
+    #[mh(code = crate::SHA1, hasher = crate::Sha1)]
     Sha1(crate::Sha1Digest<crate::U20>),
     /// Multihash array for hash function.
-    #[mh(code = 0x12, hasher = crate::Sha2_256)]
+    #[mh(code = crate::SHA2_256, hasher = crate::Sha2_256)]
     Sha2_256(crate::Sha2Digest<crate::U32>),
     /// Multihash array for hash function.
-    #[mh(code = 0x13, hasher = crate::Sha2_512)]
+    #[mh(code = crate::SHA2_512, hasher = crate::Sha2_512)]
     Sha2_512(crate::Sha2Digest<crate::U64>),
     /// Multihash array for hash function.
-    #[mh(code = 0x17, hasher = crate::Sha3_224)]
+    #[mh(code = crate::SHA3_224, hasher = crate::Sha3_224)]
     Sha3_224(crate::Sha3Digest<crate::U28>),
     /// Multihash array for hash function.
-    #[mh(code = 0x16, hasher = crate::Sha3_256)]
+    #[mh(code = crate::SHA3_256, hasher = crate::Sha3_256)]
     Sha3_256(crate::Sha3Digest<crate::U32>),
     /// Multihash array for hash function.
-    #[mh(code = 0x15, hasher = crate::Sha3_384)]
+    #[mh(code = crate::SHA3_384, hasher = crate::Sha3_384)]
     Sha3_384(crate::Sha3Digest<crate::U48>),
     /// Multihash array for hash function.
-    #[mh(code = 0x14, hasher = crate::Sha3_512)]
+    #[mh(code = crate::SHA3_512, hasher = crate::Sha3_512)]
     Sha3_512(crate::Sha3Digest<crate::U64>),
     /// Multihash array for hash function.
-    #[mh(code = 0x1a, hasher = crate::Keccak224)]
+    #[mh(code = crate::KECCAK_224, hasher = crate::Keccak224)]
     Keccak224(crate::KeccakDigest<crate::U28>),
     /// Multihash array for hash function.
-    #[mh(code = 0x1b, hasher = crate::Keccak256)]
+    #[mh(code = crate::KECCAK_256, hasher = crate::Keccak256)]
     Keccak256(crate::KeccakDigest<crate::U32>),
     /// Multihash array for hash function.
-    #[mh(code = 0x1c, hasher = crate::Keccak384)]
+    #[mh(code = crate::KECCAK_384, hasher = crate::Keccak384)]
     Keccak384(crate::KeccakDigest<crate::U48>),
     /// Multihash array for hash function.
-    #[mh(code = 0x1d, hasher = crate::Keccak512)]
+    #[mh(code = crate::KECCAK_512, hasher = crate::Keccak512)]
     Keccak512(crate::KeccakDigest<crate::U64>),
     /// Multihash array for hash function.
-    #[mh(code = 0xb220, hasher = crate::Blake2b256)]
+    #[mh(code = crate::BLAKE2B_256, hasher = crate::Blake2b256)]
     Blake2b256(crate::Blake2bDigest<crate::U32>),
     /// Multihash array for hash function.
-    #[mh(code = 0xb240, hasher = crate::Blake2b512)]
+    #[mh(code = crate::BLAKE2B_512, hasher = crate::Blake2b512)]
     Blake2b512(crate::Blake2bDigest<crate::U64>),
     /// Multihash array for hash function.
-    #[mh(code = 0xb250, hasher = crate::Blake2s128)]
+    #[mh(code = crate::BLAKE2S_128, hasher = crate::Blake2s128)]
     Blake2s128(crate::Blake2sDigest<crate::U16>),
     /// Multihash array for hash function.
-    #[mh(code = 0xb260, hasher = crate::Blake2s256)]
+    #[mh(code = crate::BLAKE2S_256, hasher = crate::Blake2s256)]
     Blake2s256(crate::Blake2sDigest<crate::U32>),
     /// Multihash array for hash function.
-    #[mh(code = 0xa0, hasher = crate::Strobe256)]
+    #[mh(code = crate::STROBE_256, hasher = crate::Strobe256)]
     Strobe256(crate::StrobeDigest<crate::U32>),
     /// Multihash array for hash function.
-    #[mh(code = 0xa1, hasher = crate::Strobe512)]
+    #[mh(code = crate::STROBE_512, hasher = crate::Strobe512)]
     Strobe512(crate::StrobeDigest<crate::U64>),
 }
 
@@ -67,9 +86,6 @@ mod tests {
     use crate::hasher::Hasher;
     use crate::hasher_impl::strobe::{Strobe256, Strobe512};
     use crate::multihash::{MultihashCreate, MultihashDigest};
-
-    const STROBE_256: u64 = 0xa0;
-    const STROBE_512: u64 = 0xa1;
 
     #[test]
     fn test_hasher_256() {

--- a/src/code.rs
+++ b/src/code.rs
@@ -66,7 +66,7 @@ mod tests {
     use super::*;
     use crate::hasher::Hasher;
     use crate::hasher_impl::strobe::{Strobe256, Strobe512};
-    use crate::multihash::MultihashDigest;
+    use crate::multihash::{MultihashCreate, MultihashDigest};
 
     const STROBE_256: u64 = 0xa0;
     const STROBE_512: u64 = 0xa1;

--- a/src/code.rs
+++ b/src/code.rs
@@ -1,80 +1,64 @@
 //! Default Code and Multihash implementation.
+use crate::hasher::Hasher;
+use crate::multihash::MultihashDigest;
 use multihash_proc_macro::Multihash;
 
-/// Default code enum.
-#[derive(Clone, Copy, Debug, Eq, Hash, Multihash, PartialEq)]
-pub enum Code {
-    /// Identity (32-byte size)
-    #[mh(code = 0x00, hasher = crate::Identity256, digest = crate::IdentityDigest<crate::U32>)]
-    Identity256,
-    /// SHA-1 (20-byte hash size)
-    #[cfg(feature = "sha1")]
-    #[mh(code = 0x11, hasher = crate::Sha1, digest = crate::Sha1Digest<crate::U20>)]
-    Sha1,
-    /// SHA-256 (32-byte hash size)
-    #[cfg(feature = "sha2")]
-    #[mh(code = 0x12, hasher = crate::Sha2_256, digest = crate::Sha2Digest<crate::U32>)]
-    Sha2_256,
-    /// SHA-512 (64-byte hash size)
-    #[cfg(feature = "sha2")]
-    #[mh(code = 0x13, hasher = crate::Sha2_512, digest = crate::Sha2Digest<crate::U64>)]
-    Sha2_512,
-    /// SHA3-224 (28-byte hash size)
-    #[cfg(feature = "sha3")]
-    #[mh(code = 0x17, hasher = crate::Sha3_224, digest = crate::Sha3Digest<crate::U28>)]
-    Sha3_224,
-    /// SHA3-256 (32-byte hash size)
-    #[cfg(feature = "sha3")]
-    #[mh(code = 0x16, hasher = crate::Sha3_256, digest = crate::Sha3Digest<crate::U32>)]
-    Sha3_256,
-    /// SHA3-384 (48-byte hash size)
-    #[cfg(feature = "sha3")]
-    #[mh(code = 0x15, hasher = crate::Sha3_384, digest = crate::Sha3Digest<crate::U48>)]
-    Sha3_384,
-    /// SHA3-512 (64-byte hash size)
-    #[cfg(feature = "sha3")]
-    #[mh(code = 0x14, hasher = crate::Sha3_512, digest = crate::Sha3Digest<crate::U64>)]
-    Sha3_512,
-    /// Keccak-224 (28-byte hash size)
-    #[cfg(feature = "sha3")]
-    #[mh(code = 0x1a, hasher = crate::Keccak224, digest = crate::KeccakDigest<crate::U28>)]
-    Keccak224,
-    /// Keccak-256 (32-byte hash size)
-    #[cfg(feature = "sha3")]
-    #[mh(code = 0x1b, hasher = crate::Keccak256, digest = crate::KeccakDigest<crate::U32>)]
-    Keccak256,
-    /// Keccak-384 (48-byte hash size)
-    #[cfg(feature = "sha3")]
-    #[mh(code = 0x1c, hasher = crate::Keccak384, digest = crate::KeccakDigest<crate::U48>)]
-    Keccak384,
-    /// Keccak-512 (64-byte hash size)
-    #[cfg(feature = "sha3")]
-    #[mh(code = 0x1d, hasher = crate::Keccak512, digest = crate::KeccakDigest<crate::U64>)]
-    Keccak512,
-    /// BLAKE2b-256 (32-byte hash size)
-    #[cfg(feature = "blake2b")]
-    #[mh(code = 0xb220, hasher = crate::Blake2b256, digest = crate::Blake2bDigest<crate::U32>)]
-    Blake2b256,
-    /// BLAKE2b-512 (64-byte hash size)
-    #[cfg(feature = "blake2b")]
-    #[mh(code = 0xb240, hasher = crate::Blake2b512, digest = crate::Blake2bDigest<crate::U64>)]
-    Blake2b512,
-    /// BLAKE2s-128 (16-byte hash size)
-    #[cfg(feature = "blake2s")]
-    #[mh(code = 0xb250, hasher = crate::Blake2s128, digest = crate::Blake2sDigest<crate::U16>)]
-    Blake2s128,
-    /// BLAKE2s-256 (32-byte hash size)
-    #[cfg(feature = "blake2s")]
-    #[mh(code = 0xb260, hasher = crate::Blake2s256, digest = crate::Blake2sDigest<crate::U32>)]
-    Blake2s256,
-    /// Strobe 256 (32-byte hash size)
-    #[cfg(feature = "strobe")]
-    #[mh(code = 0xa0, hasher = crate::Strobe256, digest = crate::StrobeDigest<crate::U32>)]
-    Strobe256,
-    /// Strobe 512 (64-byte hash size)
-    #[cfg(feature = "strobe")]
-    #[mh(code = 0xa1, hasher = crate::Strobe512, digest = crate::StrobeDigest<crate::U64>)]
-    Strobe512,
+#[derive(Clone, Debug, Eq, Multihash, PartialEq)]
+pub enum Multihash {
+    /// Multihash array for hash function.
+    #[mh(code = 0x00, hasher = crate::Identity256)]
+    Identity256(crate::IdentityDigest<crate::U32>),
+    /// Multihash array for hash function.
+    #[mh(code = 0x11, hasher = crate::Sha1)]
+    Sha1(crate::Sha1Digest<crate::U20>),
+    /// Multihash array for hash function.
+    #[mh(code = 0x12, hasher = crate::Sha2_256)]
+    Sha2_256(crate::Sha2Digest<crate::U32>),
+    /// Multihash array for hash function.
+    #[mh(code = 0x13, hasher = crate::Sha2_512)]
+    Sha2_512(crate::Sha2Digest<crate::U64>),
+    /// Multihash array for hash function.
+    #[mh(code = 0x17, hasher = crate::Sha3_224)]
+    Sha3_224(crate::Sha3Digest<crate::U28>),
+    /// Multihash array for hash function.
+    #[mh(code = 0x16, hasher = crate::Sha3_256)]
+    Sha3_256(crate::Sha3Digest<crate::U32>),
+    /// Multihash array for hash function.
+    #[mh(code = 0x15, hasher = crate::Sha3_384)]
+    Sha3_384(crate::Sha3Digest<crate::U48>),
+    /// Multihash array for hash function.
+    #[mh(code = 0x14, hasher = crate::Sha3_512)]
+    Sha3_512(crate::Sha3Digest<crate::U64>),
+    /// Multihash array for hash function.
+    #[mh(code = 0x1a, hasher = crate::Keccak224)]
+    Keccak224(crate::KeccakDigest<crate::U28>),
+    /// Multihash array for hash function.
+    #[mh(code = 0x1b, hasher = crate::Keccak256)]
+    Keccak256(crate::KeccakDigest<crate::U32>),
+    /// Multihash array for hash function.
+    #[mh(code = 0x1c, hasher = crate::Keccak384)]
+    Keccak384(crate::KeccakDigest<crate::U48>),
+    /// Multihash array for hash function.
+    #[mh(code = 0x1d, hasher = crate::Keccak512)]
+    Keccak512(crate::KeccakDigest<crate::U64>),
+    /// Multihash array for hash function.
+    #[mh(code = 0xb220, hasher = crate::Blake2b256)]
+    Blake2b256(crate::Blake2bDigest<crate::U32>),
+    /// Multihash array for hash function.
+    #[mh(code = 0xb240, hasher = crate::Blake2b512)]
+    Blake2b512(crate::Blake2bDigest<crate::U64>),
+    /// Multihash array for hash function.
+    #[mh(code = 0xb250, hasher = crate::Blake2s128)]
+    Blake2s128(crate::Blake2sDigest<crate::U16>),
+    /// Multihash array for hash function.
+    #[mh(code = 0xb260, hasher = crate::Blake2s256)]
+    Blake2s256(crate::Blake2sDigest<crate::U32>),
+    /// Multihash array for hash function.
+    #[mh(code = 0xa0, hasher = crate::Strobe256)]
+    Strobe256(crate::StrobeDigest<crate::U32>),
+    /// Multihash array for hash function.
+    #[mh(code = 0xa1, hasher = crate::Strobe512)]
+    Strobe512(crate::StrobeDigest<crate::U64>),
 }
 
 #[cfg(test)]
@@ -82,14 +66,17 @@ mod tests {
     use super::*;
     use crate::hasher::Hasher;
     use crate::hasher_impl::strobe::{Strobe256, Strobe512};
-    use crate::multihash::{MultihashCode, MultihashDigest};
+    use crate::multihash::MultihashDigest;
+
+    const STROBE_256: u64 = 0xa0;
+    const STROBE_512: u64 = 0xa1;
 
     #[test]
     fn test_hasher_256() {
         let digest = Strobe256::digest(b"hello world");
         let hash = Multihash::from(digest.clone());
-        let hash2 = Code::Strobe256.digest(b"hello world");
-        assert_eq!(hash.code(), Code::Strobe256);
+        let hash2 = Multihash::new(STROBE_256, b"hello world").unwrap();
+        assert_eq!(hash.code(), STROBE_256);
         assert_eq!(hash.size(), 32);
         assert_eq!(hash.digest(), digest.as_ref());
         assert_eq!(hash, hash2);
@@ -99,8 +86,8 @@ mod tests {
     fn test_hasher_512() {
         let digest = Strobe512::digest(b"hello world");
         let hash = Multihash::from(digest.clone());
-        let hash2 = Code::Strobe512.digest(b"hello world");
-        assert_eq!(hash.code(), Code::Strobe512);
+        let hash2 = Multihash::new(STROBE_512, b"hello world").unwrap();
+        assert_eq!(hash.code(), STROBE_512);
         assert_eq!(hash.size(), 64);
         assert_eq!(hash.digest(), digest.as_ref());
         assert_eq!(hash, hash2);

--- a/src/hasher_impl.rs
+++ b/src/hasher_impl.rs
@@ -208,6 +208,11 @@ pub mod identity {
     pub type Identity256 = IdentityHasher<U32>;
 }
 
+pub mod unknown {
+    use super::*;
+    derive_digest!(UnknownDigest);
+}
+
 #[cfg(feature = "strobe")]
 pub mod strobe {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,10 @@
 //! Multihash implementation.
-#![deny(missing_docs)]
+//#![deny(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(any(test, feature = "test"))]
-mod arb;
+// TODO vmx 2020-07-27: Fix it
+//#[cfg(any(test, feature = "test"))]
+//mod arb;
 #[cfg(feature = "code")]
 pub mod code;
 mod error;
@@ -17,7 +18,8 @@ pub use crate::hasher::WriteHasher;
 pub use crate::hasher::{Digest, Hasher, Size};
 #[cfg(feature = "std")]
 pub use crate::multihash::{read_code, read_digest, write_mh};
-pub use crate::multihash::{MultihashCode, MultihashDigest};
+//pub use crate::multihash::{MultihashCode, MultihashDigest};
+pub use crate::multihash::MultihashDigest;
 pub use generic_array::typenum::{self, U16, U20, U28, U32, U48, U64};
 #[cfg(feature = "derive")]
 pub use multihash_proc_macro::Multihash;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub use crate::hasher::{Digest, Hasher, Size};
 #[cfg(feature = "std")]
 pub use crate::multihash::{read_code, read_digest, write_mh};
 //pub use crate::multihash::{MultihashCode, MultihashDigest};
-pub use crate::multihash::{MultihashCreate, MultihashDigest};
+pub use crate::multihash::{BasicMultihash, MultihashCreate, MultihashDigest};
 pub use generic_array::typenum::{self, U16, U20, U28, U32, U48, U64};
 #[cfg(feature = "derive")]
 pub use multihash_proc_macro::Multihash;
@@ -39,3 +39,4 @@ pub use crate::hasher_impl::sha3::{Keccak224, Keccak256, Keccak384, Keccak512, K
 pub use crate::hasher_impl::sha3::{Sha3Digest, Sha3_224, Sha3_256, Sha3_384, Sha3_512};
 #[cfg(feature = "strobe")]
 pub use crate::hasher_impl::strobe::{Strobe256, Strobe512, StrobeDigest, StrobeHasher};
+pub use crate::hasher_impl::unknown::UnknownDigest;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,8 @@
 #![deny(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-// TODO vmx 2020-07-27: Fix it
-//#[cfg(any(test, feature = "test"))]
-//mod arb;
+#[cfg(any(test, feature = "test"))]
+mod arb;
 #[cfg(feature = "code")]
 pub mod code;
 mod error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,6 @@ pub use crate::hasher::WriteHasher;
 pub use crate::hasher::{Digest, Hasher, Size};
 #[cfg(feature = "std")]
 pub use crate::multihash::{read_code, read_digest, write_mh};
-//pub use crate::multihash::{MultihashCode, MultihashDigest};
 pub use crate::multihash::{MultihashCreate, MultihashDigest, RawMultihash};
 pub use generic_array::typenum::{self, U16, U20, U28, U32, U48, U64};
 #[cfg(feature = "derive")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,13 @@ pub use generic_array::typenum::{self, U16, U20, U28, U32, U48, U64};
 #[cfg(feature = "derive")]
 pub use multihash_proc_macro::Multihash;
 
+#[cfg(feature = "code")]
+pub use crate::code::{
+    BLAKE2B_256, BLAKE2B_512, BLAKE2S_128, BLAKE2S_256, IDENTITY, KECCAK_224, KECCAK_256,
+    KECCAK_384, KECCAK_512, SHA1, SHA2_256, SHA2_512, SHA3_224, SHA3_256, SHA3_384, SHA3_512,
+    STROBE_256, STROBE_512,
+};
+
 #[cfg(feature = "blake2b")]
 pub use crate::hasher_impl::blake2b::{Blake2b256, Blake2b512, Blake2bDigest, Blake2bHasher};
 #[cfg(feature = "blake2s")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub use crate::hasher::{Digest, Hasher, Size};
 #[cfg(feature = "std")]
 pub use crate::multihash::{read_code, read_digest, write_mh};
 //pub use crate::multihash::{MultihashCode, MultihashDigest};
-pub use crate::multihash::MultihashDigest;
+pub use crate::multihash::{MultihashCreate, MultihashDigest};
 pub use generic_array::typenum::{self, U16, U20, U28, U32, U48, U64};
 #[cfg(feature = "derive")]
 pub use multihash_proc_macro::Multihash;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub use crate::hasher::{Digest, Hasher, Size};
 #[cfg(feature = "std")]
 pub use crate::multihash::{read_code, read_digest, write_mh};
 //pub use crate::multihash::{MultihashCode, MultihashDigest};
-pub use crate::multihash::{BasicMultihash, MultihashCreate, MultihashDigest};
+pub use crate::multihash::{MultihashCreate, MultihashDigest, RawMultihash};
 pub use generic_array::typenum::{self, U16, U20, U28, U32, U48, U64};
 #[cfg(feature = "derive")]
 pub use multihash_proc_macro::Multihash;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! Multihash implementation.
-//#![deny(missing_docs)]
+#![deny(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 // TODO vmx 2020-07-27: Fix it

--- a/src/multihash.rs
+++ b/src/multihash.rs
@@ -1,7 +1,10 @@
 use crate::error::Error;
 use core::fmt::Debug;
 
-/// Trait for a multihash digest.
+/// Trait for reading and writhing Multihashes.
+///
+/// This traits operates on existing hashes. Creation of new hashes is done by the
+/// [`MultihashCreate`] trait.
 pub trait MultihashDigest: Clone + Debug + Eq + Send + Sync + 'static {
     //const CODE: u64;
 
@@ -13,9 +16,6 @@ pub trait MultihashDigest: Clone + Debug + Eq + Send + Sync + 'static {
 
     /// Returns the digest.
     fn digest(&self) -> &[u8];
-
-    ///// Returns the hash of the input.
-    fn new(code: u64, input: &[u8]) -> Result<Self, Error>;
 
     /// Reads a multihash from a byte stream.
     #[cfg(feature = "std")]
@@ -46,6 +46,12 @@ pub trait MultihashDigest: Clone + Debug + Eq + Send + Sync + 'static {
             .expect("writing to a vec should never fail");
         bytes
     }
+}
+
+/// Trait that makes it possible to create a new hash from some data.
+pub trait MultihashCreate: Clone + Debug + Eq + Send + Sync + 'static {
+    /// Returns the hash of the input.
+    fn new(code: u64, input: &[u8]) -> Result<Self, Error>;
 }
 
 /// Writes the multihash to a byte stream.

--- a/src/multihash.rs
+++ b/src/multihash.rs
@@ -118,7 +118,7 @@ where
     use unsigned_varint::encode as varint_encode;
 
     let mut code_buf = varint_encode::u64_buffer();
-    let code = varint_encode::u64(mh.code().into(), &mut code_buf);
+    let code = varint_encode::u64(mh.code(), &mut code_buf);
 
     let mut size_buf = varint_encode::u8_buffer();
     let size = varint_encode::u8(mh.size(), &mut size_buf);

--- a/src/multihash.rs
+++ b/src/multihash.rs
@@ -62,7 +62,7 @@ pub trait MultihashCreate: Clone + Debug + Eq + Send + Sync + 'static {
 /// # Example
 ///
 /// ```
-/// use multihash::{BasicMultihash, MultihashDigest};
+/// use multihash::{MultihashDigest, RawMultihash};
 ///
 /// const Sha3_256: u64 = 0x16;
 /// let digest_bytes = [
@@ -70,13 +70,13 @@ pub trait MultihashCreate: Clone + Debug + Eq + Send + Sync + 'static {
 ///     0x76, 0x22, 0xf3, 0xca, 0x71, 0xfb, 0xa1, 0xd9, 0x72, 0xfd, 0x94, 0xa3, 0x1c, 0x3b, 0xfb,
 ///     0xf2, 0x4e, 0x39, 0x38,
 /// ];
-/// let mh = BasicMultihash::from_bytes(&digest_bytes).unwrap();
+/// let mh = RawMultihash::from_bytes(&digest_bytes).unwrap();
 /// assert_eq!(mh.code(), Sha3_256);
 /// assert_eq!(mh.size(), 32);
 /// assert_eq!(mh.digest(), &digest_bytes[2..]);
 /// ```
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct BasicMultihash {
+pub struct RawMultihash {
     /// The code of the Multihash.
     code: u64,
     /// The actual size of the digest in bytes (not the allocated size).
@@ -85,7 +85,7 @@ pub struct BasicMultihash {
     digest: crate::UnknownDigest<crate::U32>,
 }
 
-impl MultihashDigest for BasicMultihash {
+impl MultihashDigest for RawMultihash {
     fn code(&self) -> u64 {
         self.code
     }
@@ -104,7 +104,7 @@ impl MultihashDigest for BasicMultihash {
         Self: Sized,
     {
         let (code, size, digest) = read_multihash(r)?;
-        Ok(BasicMultihash { code, size, digest })
+        Ok(Self { code, size, digest })
     }
 }
 

--- a/tests/custom_table.rs
+++ b/tests/custom_table.rs
@@ -1,4 +1,6 @@
-use multihash::{read_code, read_digest, Error, Hasher, Multihash, MultihashDigest};
+use multihash::{
+    read_code, read_digest, Error, Hasher, Multihash, MultihashCreate, MultihashDigest,
+};
 
 #[derive(Clone, Debug, Eq, Multihash, PartialEq)]
 pub enum Multihash {

--- a/tests/custom_table.rs
+++ b/tests/custom_table.rs
@@ -2,10 +2,13 @@ use multihash::{
     read_code, read_digest, Error, Hasher, Multihash, MultihashCreate, MultihashDigest,
 };
 
+const FOO: u64 = 0x01;
+const BAR: u64 = 0x02;
+
 #[derive(Clone, Debug, Eq, Multihash, PartialEq)]
 pub enum Multihash {
-    #[mh(code = 0x01, hasher = multihash::Sha2_256)]
+    #[mh(code = FOO, hasher = multihash::Sha2_256)]
     Foo(multihash::Sha2Digest<multihash::U32>),
-    #[mh(code = 0x02, hasher = multihash::Sha2_512)]
+    #[mh(code = BAR, hasher = multihash::Sha2_512)]
     Bar(multihash::Sha2Digest<multihash::U64>),
 }

--- a/tests/custom_table.rs
+++ b/tests/custom_table.rs
@@ -1,12 +1,9 @@
-#[macro_use]
-extern crate multihash;
+use multihash::{read_code, read_digest, Error, Hasher, Multihash, MultihashDigest};
 
-use multihash::{read_code, read_digest, Error, Hasher, MultihashCode, MultihashDigest};
-
-#[derive(Clone, Copy, Debug, Eq, Hash, Multihash, PartialEq)]
-enum MyCodeTable {
-    #[mh(code = 0x1, hasher = multihash::Sha2_256, digest = multihash::Sha2Digest<multihash::U32>)]
-    Foo,
-    #[mh(code = 0x2, hasher = multihash::Sha2_512, digest = multihash::Sha2Digest<multihash::U64>)]
-    Bar,
+#[derive(Clone, Debug, Eq, Multihash, PartialEq)]
+pub enum Multihash {
+    #[mh(code = 0x01, hasher = multihash::Sha2_256)]
+    Foo(multihash::Sha2Digest<multihash::U32>),
+    #[mh(code = 0x02, hasher = multihash::Sha2_512)]
+    Bar(multihash::Sha2Digest<multihash::U64>),
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,6 +1,3 @@
-// TODO vmx 2020-07-27: do actually use uppercase
-#![allow(non_upper_case_globals)]
-
 use multihash::code::*;
 use multihash::*;
 
@@ -14,22 +11,6 @@ fn hex_to_bytes(s: &str) -> Vec<u8> {
     }
     v
 }
-
-const Sha1: u64 = 0x11;
-const Sha2_256: u64 = 0x12;
-const Sha2_512: u64 = 0x13;
-const Sha3_224: u64 = 0x17;
-const Sha3_256: u64 = 0x16;
-const Sha3_384: u64 = 0x15;
-const Sha3_512: u64 = 0x14;
-const Keccak224: u64 = 0x1a;
-const Keccak256: u64 = 0x1b;
-const Keccak384: u64 = 0x1c;
-const Keccak512: u64 = 0x1d;
-const Blake2b256: u64 = 0xb220;
-const Blake2b512: u64 = 0xb240;
-const Blake2s128: u64 = 0xb250;
-const Blake2s256: u64 = 0xb260;
 
 macro_rules! assert_encode {
     {$( $alg:ty, $data:expr, $expect:expr; )*} => {
@@ -95,22 +76,22 @@ macro_rules! assert_decode {
 fn assert_decode() {
     assert_decode! {
         //Identity256, "000a68656c6c6f776f726c64";
-        Sha1, "11147c8357577f51d4f0a8d393aa1aaafb28863d9421";
-        Sha2_256, "1220936a185caaa266bb9cbe981e9e05cb78cd732b0b3280eb944412bb6f8f8f07af";
-        Sha2_256, "122090ea688e275d580567325032492b597bc77221c62493e76330b85ddda191ef7c";
-        Sha2_512, "1340309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f";
-        Sha3_224, "171Cdfb7f18c77e928bb56faeb2da27291bd790bc1045cde45f3210bb6c5";
-        Sha3_256, "1620644bcc7e564373040999aac89e7622f3ca71fba1d972fd94a31c3bfbf24e3938";
-        Sha3_384, "153083bff28dde1b1bf5810071c6643c08e5b05bdb836effd70b403ea8ea0a634dc4997eb1053aa3593f590f9c63630dd90b";
-        Sha3_512, "1440840006653e9ac9e95117a15c915caab81662918e925de9e004f774ff82d7079a40d4d27b1b372657c61d46d470304c88c788b3a4527ad074d1dccbee5dbaa99a";
-        Keccak224, "1A1C25f3ecfebabe99686282f57f5c9e1f18244cfee2813d33f955aae568";
-        Keccak256, "1B2047173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad";
-        Keccak384, "1C3065fc99339a2a40e99d3c40d695b22f278853ca0f925cde4254bcae5e22ece47e6441f91b6568425adc9d95b0072eb49f";
-        Keccak512, "1D403ee2b40047b8060f68c67242175660f4174d0af5c01d47168ec20ed619b0b7c42181f40aa1046f39e2ef9efc6910782a998e0013d172458957957fac9405b67d";
-        Blake2b512, "c0e40240021ced8799296ceca557832ab941a50b4a11f83478cf141f51f933f653ab9fbcc05a037cddbed06e309bf334942c4e58cdf1a46e237911ccd7fcf9787cbc7fd0";
-        Blake2s256, "e0e402209aec6806794561107e594b1f6a8a6b0c92a0cba9acf5e5e93cca06f781813b0b";
-        Blake2b256, "a0e40220256c83b297114d201b30179f3f0ef0cace9783622da5974326b436178aeef610";
-        Blake2s128, "d0e4021037deae0226c30da2ab424a7b8ee14e83";
+        SHA1, "11147c8357577f51d4f0a8d393aa1aaafb28863d9421";
+        SHA2_256, "1220936a185caaa266bb9cbe981e9e05cb78cd732b0b3280eb944412bb6f8f8f07af";
+        SHA2_256, "122090ea688e275d580567325032492b597bc77221c62493e76330b85ddda191ef7c";
+        SHA2_512, "1340309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f";
+        SHA3_224, "171Cdfb7f18c77e928bb56faeb2da27291bd790bc1045cde45f3210bb6c5";
+        SHA3_256, "1620644bcc7e564373040999aac89e7622f3ca71fba1d972fd94a31c3bfbf24e3938";
+        SHA3_384, "153083bff28dde1b1bf5810071c6643c08e5b05bdb836effd70b403ea8ea0a634dc4997eb1053aa3593f590f9c63630dd90b";
+        SHA3_512, "1440840006653e9ac9e95117a15c915caab81662918e925de9e004f774ff82d7079a40d4d27b1b372657c61d46d470304c88c788b3a4527ad074d1dccbee5dbaa99a";
+        KECCAK_224, "1A1C25f3ecfebabe99686282f57f5c9e1f18244cfee2813d33f955aae568";
+        KECCAK_256, "1B2047173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad";
+        KECCAK_384, "1C3065fc99339a2a40e99d3c40d695b22f278853ca0f925cde4254bcae5e22ece47e6441f91b6568425adc9d95b0072eb49f";
+        KECCAK_512, "1D403ee2b40047b8060f68c67242175660f4174d0af5c01d47168ec20ed619b0b7c42181f40aa1046f39e2ef9efc6910782a998e0013d172458957957fac9405b67d";
+        BLAKE2B_512, "c0e40240021ced8799296ceca557832ab941a50b4a11f83478cf141f51f933f653ab9fbcc05a037cddbed06e309bf334942c4e58cdf1a46e237911ccd7fcf9787cbc7fd0";
+        BLAKE2S_256, "e0e402209aec6806794561107e594b1f6a8a6b0c92a0cba9acf5e5e93cca06f781813b0b";
+        BLAKE2B_256, "a0e40220256c83b297114d201b30179f3f0ef0cace9783622da5974326b436178aeef610";
+        BLAKE2S_128, "d0e4021037deae0226c30da2ab424a7b8ee14e83";
     }
 }
 
@@ -281,7 +262,7 @@ fn test_raw_multihash() {
     let digest_hex = "1620644bcc7e564373040999aac89e7622f3ca71fba1d972fd94a31c3bfbf24e3938";
     let digest_bytes = hex_to_bytes(digest_hex);
     let mh = RawMultihash::from_bytes(&digest_bytes).unwrap();
-    assert_eq!(mh.code(), Sha3_256);
+    assert_eq!(mh.code(), SHA3_256);
     assert_eq!(mh.size(), 32);
     assert_eq!(mh.digest(), &digest_bytes[2..]);
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,3 +1,6 @@
+// TODO vmx 2020-07-27: do actually use uppercase
+#![allow(non_upper_case_globals)]
+
 use multihash::code::*;
 use multihash::*;
 
@@ -11,6 +14,22 @@ fn hex_to_bytes(s: &str) -> Vec<u8> {
     }
     v
 }
+
+const Sha1: u64 = 0x11;
+const Sha2_256: u64 = 0x12;
+const Sha2_512: u64 = 0x13;
+const Sha3_224: u64 = 0x17;
+const Sha3_256: u64 = 0x16;
+const Sha3_384: u64 = 0x15;
+const Sha3_512: u64 = 0x14;
+const Keccak224: u64 = 0x1a;
+const Keccak256: u64 = 0x1b;
+const Keccak384: u64 = 0x1c;
+const Keccak512: u64 = 0x1d;
+const Blake2b256: u64 = 0xb220;
+const Blake2b512: u64 = 0xb240;
+const Blake2s128: u64 = 0xb250;
+const Blake2s256: u64 = 0xb260;
 
 macro_rules! assert_encode {
     {$( $alg:ty, $data:expr, $expect:expr; )*} => {
@@ -65,7 +84,7 @@ macro_rules! assert_decode {
             let hash = hex_to_bytes($hash);
             assert_eq!(
                 Multihash::from_bytes(&hash).unwrap().code(),
-                Code::$alg,
+                $alg,
                 "{:?} decodes correctly", stringify!($alg)
             );
         )*
@@ -249,7 +268,7 @@ fn multihash_errors() {
         Multihash::from_bytes(&[0x12, 0x20, 0xff]).is_err(),
         "Should error on correct prefix with wrong digest"
     );
-    let identity_code = <u64>::from(Code::Identity256) as u8;
+    let identity_code: u8 = 0x00;
     let identity_length = 3;
     assert!(
         Multihash::from_bytes(&[identity_code, identity_length, 1, 2, 3, 4]).is_err(),

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -275,3 +275,13 @@ fn multihash_errors() {
         "Should error on wrong hash length"
     );
 }
+
+#[test]
+fn test_basic_multihash() {
+    let digest_hex = "1620644bcc7e564373040999aac89e7622f3ca71fba1d972fd94a31c3bfbf24e3938";
+    let digest_bytes = hex_to_bytes(digest_hex);
+    let mh = BasicMultihash::from_bytes(&digest_bytes).unwrap();
+    assert_eq!(mh.code(), Sha3_256);
+    assert_eq!(mh.size(), 32);
+    assert_eq!(mh.digest(), &digest_bytes[2..]);
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -277,10 +277,10 @@ fn multihash_errors() {
 }
 
 #[test]
-fn test_basic_multihash() {
+fn test_raw_multihash() {
     let digest_hex = "1620644bcc7e564373040999aac89e7622f3ca71fba1d972fd94a31c3bfbf24e3938";
     let digest_bytes = hex_to_bytes(digest_hex);
-    let mh = BasicMultihash::from_bytes(&digest_bytes).unwrap();
+    let mh = RawMultihash::from_bytes(&digest_bytes).unwrap();
     assert_eq!(mh.code(), Sha3_256);
     assert_eq!(mh.size(), 32);
     assert_eq!(mh.digest(), &digest_bytes[2..]);


### PR DESCRIPTION
Instead of using a code table, derive from a Multihash enum which defines
implementations.

This leads to less generated code.

This PR is *not* intended to be merged as-is. It should be used as a basis for discussions.

I think I found a way to simplify things. I'm not fully done yet (e.g. I think I'd like to split the `MultihashDigest` trait into two pieces), but I thought I push it here to get early feedback if this might be a way to move forward.

I also have no idea how this will work with rust-cid, I haven't looked into that at all yet.