### PR TITLE
refactor: create multihash_impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ keywords = ["multihash", "ipfs"]
 license = "MIT"
 
 [features]
-default = ["std", "all", "derive", "code"]
+default = ["std", "all", "derive", "multihash-impl"]
 std = []
-code = ["derive"]
+multihash-impl = ["derive", "all"]
 derive = ["multihash-proc-macro"]
-test = ["code", "quickcheck", "rand"]
+test = ["multihash-impl", "quickcheck", "rand"]
 all = ["blake2b", "blake2s", "sha1", "sha2", "sha3", "strobe"]
 
 blake2b = ["blake2b_simd"]

--- a/src/arb.rs
+++ b/src/arb.rs
@@ -1,8 +1,12 @@
 use quickcheck::{Arbitrary, Gen};
 use rand::seq::SliceRandom;
 
-use crate::code::*;
-use crate::MultihashCreate;
+use crate::multihash::MultihashCreate;
+use crate::multihash_impl::{
+    Multihash, BLAKE2B_256, BLAKE2B_512, BLAKE2S_128, BLAKE2S_256, IDENTITY, KECCAK_224,
+    KECCAK_256, KECCAK_384, KECCAK_512, SHA1, SHA2_256, SHA2_512, SHA3_224, SHA3_256, SHA3_384,
+    SHA3_512,
+};
 
 const HASHES: [u64; 16] = [
     IDENTITY,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,12 +4,12 @@
 
 #[cfg(any(test, feature = "test"))]
 mod arb;
-#[cfg(feature = "code")]
-pub mod code;
 mod error;
 mod hasher;
 mod hasher_impl;
 mod multihash;
+#[cfg(feature = "multihash-impl")]
+mod multihash_impl;
 
 pub use crate::error::{Error, Result};
 #[cfg(feature = "std")]
@@ -20,13 +20,13 @@ pub use crate::multihash::{read_code, read_digest, write_mh};
 pub use crate::multihash::{MultihashCreate, MultihashDigest, RawMultihash};
 pub use generic_array::typenum::{self, U16, U20, U28, U32, U48, U64};
 #[cfg(feature = "derive")]
-pub use multihash_proc_macro::Multihash;
+pub use multihash_proc_macro as derive;
 
-#[cfg(feature = "code")]
-pub use crate::code::{
-    BLAKE2B_256, BLAKE2B_512, BLAKE2S_128, BLAKE2S_256, IDENTITY, KECCAK_224, KECCAK_256,
-    KECCAK_384, KECCAK_512, SHA1, SHA2_256, SHA2_512, SHA3_224, SHA3_256, SHA3_384, SHA3_512,
-    STROBE_256, STROBE_512,
+#[cfg(feature = "multihash-impl")]
+pub use crate::multihash_impl::{
+    Multihash, BLAKE2B_256, BLAKE2B_512, BLAKE2S_128, BLAKE2S_256, IDENTITY, KECCAK_224,
+    KECCAK_256, KECCAK_384, KECCAK_512, SHA1, SHA2_256, SHA2_512, SHA3_224, SHA3_256, SHA3_384,
+    SHA3_512, STROBE_256, STROBE_512,
 };
 
 #[cfg(feature = "blake2b")]

--- a/src/multihash.rs
+++ b/src/multihash.rs
@@ -192,9 +192,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::code::Multihash;
     use crate::hasher::Hasher;
     use crate::hasher_impl::strobe::Strobe256;
+    use crate::multihash_impl::Multihash;
 
     #[test]
     fn roundtrip() {

--- a/src/multihash_impl.rs
+++ b/src/multihash_impl.rs
@@ -44,58 +44,58 @@ pub const STROBE_512: u64 = 0xa1;
 #[derive(Clone, Debug, Eq, Multihash, PartialEq)]
 pub enum Multihash {
     /// Multihash array for hash function.
-    #[mh(code = crate::IDENTITY, hasher = crate::Identity256)]
+    #[mh(code = self::IDENTITY, hasher = crate::Identity256)]
     Identity256(crate::IdentityDigest<crate::U32>),
     /// Multihash array for hash function.
-    #[mh(code = crate::SHA1, hasher = crate::Sha1)]
+    #[mh(code = self::SHA1, hasher = crate::Sha1)]
     Sha1(crate::Sha1Digest<crate::U20>),
     /// Multihash array for hash function.
-    #[mh(code = crate::SHA2_256, hasher = crate::Sha2_256)]
+    #[mh(code = self::SHA2_256, hasher = crate::Sha2_256)]
     Sha2_256(crate::Sha2Digest<crate::U32>),
     /// Multihash array for hash function.
-    #[mh(code = crate::SHA2_512, hasher = crate::Sha2_512)]
+    #[mh(code = self::SHA2_512, hasher = crate::Sha2_512)]
     Sha2_512(crate::Sha2Digest<crate::U64>),
     /// Multihash array for hash function.
-    #[mh(code = crate::SHA3_224, hasher = crate::Sha3_224)]
+    #[mh(code = self::SHA3_224, hasher = crate::Sha3_224)]
     Sha3_224(crate::Sha3Digest<crate::U28>),
     /// Multihash array for hash function.
-    #[mh(code = crate::SHA3_256, hasher = crate::Sha3_256)]
+    #[mh(code = self::SHA3_256, hasher = crate::Sha3_256)]
     Sha3_256(crate::Sha3Digest<crate::U32>),
     /// Multihash array for hash function.
-    #[mh(code = crate::SHA3_384, hasher = crate::Sha3_384)]
+    #[mh(code = self::SHA3_384, hasher = crate::Sha3_384)]
     Sha3_384(crate::Sha3Digest<crate::U48>),
     /// Multihash array for hash function.
-    #[mh(code = crate::SHA3_512, hasher = crate::Sha3_512)]
+    #[mh(code = self::SHA3_512, hasher = crate::Sha3_512)]
     Sha3_512(crate::Sha3Digest<crate::U64>),
     /// Multihash array for hash function.
-    #[mh(code = crate::KECCAK_224, hasher = crate::Keccak224)]
+    #[mh(code = self::KECCAK_224, hasher = crate::Keccak224)]
     Keccak224(crate::KeccakDigest<crate::U28>),
     /// Multihash array for hash function.
-    #[mh(code = crate::KECCAK_256, hasher = crate::Keccak256)]
+    #[mh(code = self::KECCAK_256, hasher = crate::Keccak256)]
     Keccak256(crate::KeccakDigest<crate::U32>),
     /// Multihash array for hash function.
-    #[mh(code = crate::KECCAK_384, hasher = crate::Keccak384)]
+    #[mh(code = self::KECCAK_384, hasher = crate::Keccak384)]
     Keccak384(crate::KeccakDigest<crate::U48>),
     /// Multihash array for hash function.
-    #[mh(code = crate::KECCAK_512, hasher = crate::Keccak512)]
+    #[mh(code = self::KECCAK_512, hasher = crate::Keccak512)]
     Keccak512(crate::KeccakDigest<crate::U64>),
     /// Multihash array for hash function.
-    #[mh(code = crate::BLAKE2B_256, hasher = crate::Blake2b256)]
+    #[mh(code = self::BLAKE2B_256, hasher = crate::Blake2b256)]
     Blake2b256(crate::Blake2bDigest<crate::U32>),
     /// Multihash array for hash function.
-    #[mh(code = crate::BLAKE2B_512, hasher = crate::Blake2b512)]
+    #[mh(code = self::BLAKE2B_512, hasher = crate::Blake2b512)]
     Blake2b512(crate::Blake2bDigest<crate::U64>),
     /// Multihash array for hash function.
-    #[mh(code = crate::BLAKE2S_128, hasher = crate::Blake2s128)]
+    #[mh(code = self::BLAKE2S_128, hasher = crate::Blake2s128)]
     Blake2s128(crate::Blake2sDigest<crate::U16>),
     /// Multihash array for hash function.
-    #[mh(code = crate::BLAKE2S_256, hasher = crate::Blake2s256)]
+    #[mh(code = self::BLAKE2S_256, hasher = crate::Blake2s256)]
     Blake2s256(crate::Blake2sDigest<crate::U32>),
     /// Multihash array for hash function.
-    #[mh(code = crate::STROBE_256, hasher = crate::Strobe256)]
+    #[mh(code = self::STROBE_256, hasher = crate::Strobe256)]
     Strobe256(crate::StrobeDigest<crate::U32>),
     /// Multihash array for hash function.
-    #[mh(code = crate::STROBE_512, hasher = crate::Strobe512)]
+    #[mh(code = self::STROBE_512, hasher = crate::Strobe512)]
     Strobe512(crate::StrobeDigest<crate::U64>),
 }
 

--- a/tests/custom_table.rs
+++ b/tests/custom_table.rs
@@ -1,6 +1,5 @@
-use multihash::{
-    read_code, read_digest, Error, Hasher, Multihash, MultihashCreate, MultihashDigest,
-};
+use multihash::derive::Multihash;
+use multihash::{read_code, read_digest, Error, Hasher, MultihashCreate, MultihashDigest};
 
 const FOO: u64 = 0x01;
 const BAR: u64 = 0x02;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,5 +1,10 @@
-use multihash::code::*;
-use multihash::*;
+use multihash::{
+    Blake2b256, Blake2b512, Blake2s128, Blake2s256, Hasher, Identity256, Keccak224, Keccak256,
+    Keccak384, Keccak512, Multihash, MultihashDigest, RawMultihash, Sha1, Sha2_256, Sha2_512,
+    Sha3_224, Sha3_256, Sha3_384, Sha3_512, BLAKE2B_256, BLAKE2B_512, BLAKE2S_128, BLAKE2S_256,
+    KECCAK_224, KECCAK_256, KECCAK_384, KECCAK_512, SHA1, SHA2_256, SHA2_512, SHA3_224, SHA3_256,
+    SHA3_384, SHA3_512,
+};
 
 /// Helper function to convert a hex-encoded byte array back into a bytearray
 fn hex_to_bytes(s: &str) -> Vec<u8> {


### PR DESCRIPTION
The `Multihash` proc macro no longer creates a code table, hence the
name `code` doesn't really apply anymore. Thus is it was renamed to
`multihash_impl.rs` which is kind of symmetric to `hasher_impl.rs`.

The proc macro is moved to a `derive` module, to have a cleaner
distinction between importing the default `Multihash` implementation
or the `Multihash` derive.

This is a refactoring I came up with. If anyone has better on how to name
things or organize things, please comment.