### PR TITLE
docs: Add more documentation

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,3 +1,24 @@
+//! This proc macro derives a [`MultihashDigest`] implementation from a list of hashers.
+//!
+//! # Example
+//!
+//! ```compile_fail
+//! use multihash::derive::Multihash;
+//! use multihash::{Hasher, MultihashDigest};
+//!
+//! const FOO: u64 = 0x01;
+//! const BAR: u64 = 0x02;
+//!
+//! #[derive(Clone, Debug, Eq, Multihash, PartialEq)]
+//! pub enum Multihash {
+//!     #[mh(code = FOO, hasher = multihash::Sha2_256)]
+//!     Foo(multihash::Sha2Digest<multihash::U32>),
+//!     #[mh(code = BAR, hasher = multihash::Sha2_512)]
+//!     Bar(multihash::Sha2Digest<multihash::U64>),
+//! }
+//! ```
+//!
+//! [`MultihashDigest`]: ../multihash/trait.MultihashDigest.html
 extern crate proc_macro;
 
 mod multihash;

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -33,28 +33,50 @@ pub trait Digest<S: Size>:
 }
 
 /// Trait implemented by a hash function implementation.
+///
+/// It specifies its own Digest type, so that the output of the hash function can later be
+/// distinguished. This way you can create a [`MultihashDigest`] from a `Digest`.
+///
+/// Every hashing algorithm that is used with Multihash needs to implement those. This trait is
+/// very similar to the external [`digest::Digest` trait]. There is a small significant
+/// difference, which needed the introduction of this `Hasher` trait instead of re-using the
+/// widely used `digest::Digest` trait.
+///
+/// The external `digest::Digest` trait has a single return type called [`Output`], which is used
+/// for all hashers that implement it. It's basically a wrapper around the hashed result bytes.
+/// For Multihashes we need to distinguish those bytes, as we care about which hash function they
+/// were created with (which is the whole point of [Multihashes]). Therefore the [`Hasher`] trait
+/// defines an [associated type] [`Hasher::Digest`] for the output of the hasher. This way the
+/// implementers can specify their own, hasher specific type (which implements [`Digest`]) for
+/// their output.
+///
+/// [`digest::Digest` trait]: https://docs.rs/digest/0.9.0/digest/trait.Digest.html
+/// [`Output`]: https://docs.rs/digest/0.9.0/digest/type.Output.html
+/// [Multihashes]: https://github.com/multiformats/multihash
+/// [associated type]: https://doc.rust-lang.org/book/ch19-03-advanced-traits.html#specifying-placeholder-types-in-trait-definitions-with-associated-types
+/// [`MultihashDigest`]: crate::MultihashDigest
 pub trait Hasher: Default {
-    /// Digest size.
+    /// The maximum Digest size for that hasher (it is stack allocated).
     type Size: Size;
 
-    /// Digest type.
+    /// The Digest type to distinguish the output of different `Hasher` implementations.
     type Digest: Digest<Self::Size>;
 
     /// Consume input and update internal state.
     fn update(&mut self, input: &[u8]);
 
-    /// Returns the internal state digest.
+    /// Returns the final digest.
     fn finalize(&self) -> Self::Digest;
 
     /// Reset the internal hasher state.
     fn reset(&mut self);
 
-    /// Returns the size of the digest.
+    /// Returns the allocated size of the digest.
     fn size() -> u8 {
         Self::Size::to_u8()
     }
 
-    /// Returns the digest of the input.
+    /// Hashes the given `input` data and returns its hash digest.
     fn digest(input: &[u8]) -> Self::Digest
     where
         Self: Sized,

--- a/src/hasher_impl.rs
+++ b/src/hasher_impl.rs
@@ -3,7 +3,7 @@ use generic_array::GenericArray;
 
 macro_rules! derive_digest {
     ($name:ident) => {
-        /// $name digest.
+        /// Multihash digest.
         #[derive(Clone, Debug, Default, Eq, PartialEq)]
         pub struct $name<S: Size>(GenericArray<u8, S>);
 
@@ -34,7 +34,7 @@ macro_rules! derive_hasher_blake {
     ($module:ident, $name:ident, $digest:ident) => {
         derive_digest!($digest);
 
-        /// $name hasher.
+        /// Multihash hasher.
         pub struct $name<S: Size> {
             _marker: PhantomData<S>,
             state: $module::State,
@@ -105,7 +105,7 @@ pub mod blake2s {
 #[cfg(feature = "digest")]
 macro_rules! derive_hasher_sha {
     ($module:ty, $name:ident, $size:ty, $digest:ident) => {
-        /// $name hasher.
+        /// Multihash hasher.
         #[derive(Default)]
         pub struct $name {
             state: $module,
@@ -204,7 +204,7 @@ pub mod identity {
         }
     }
 
-    /// 256 bit identity
+    /// 256 bit Identity hasher.
     pub type Identity256 = IdentityHasher<U32>;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,34 @@
 //! Multihash implementation.
+//!
+//! Feature Flags
+//! -------------
+//!
+//! Multihash has lots of [feature flags], by default, all features (except for `test`) are
+//! enabled.
+//!
+//! Some of them are about specific hash functions, these are:
+//!
+//!  - `blake2b`: Enable Blake2b hashers
+//!  - `blake2s`: Enable Blake2s hashers
+//!  - `sha1`: Enable SHA-1 hashers
+//!  - `sha2`: Enable SHA-2 hashers
+//!  - `sha3`: Enable SHA-3 hashers
+//!  - `strobe`: Enable Strobe hashers
+//!
+//! In order to enable all hashers, you can set the `all` feature flag.
+//!
+//! The library has support for `no_std`, if you disable the `std` feature flag.
+//!
+//! The `multihash-impl` feature flag enables a default Multihash implementation that contains all
+//! bundled hashers (which may be disabled via the feature flags mentioned above). If only want a
+//! specific subset of hash algorithms or add one which isn't supporte by default, you will likely
+//! disable that feature and enable `derive` in order to be able to use the [`Multihash` derive].
+//!
+//! The `test` feature flag enables property based testing features.
+//!
+//! [feature flags]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
+//! [`Multihash` derive]: crate::derive
+
 #![deny(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/src/multihash.rs
+++ b/src/multihash.rs
@@ -4,8 +4,9 @@ use core::fmt::Debug;
 
 /// Trait for reading and writhing Multihashes.
 ///
-/// This traits operates on existing hashes. Creation of new hashes is done by the
-/// [`MultihashCreate`] trait.
+/// It is usually derived from a list of hashers by the [`Multihash` derive].
+///
+/// [`Multihash` derive]: crate::derive
 pub trait MultihashDigest: Clone + Debug + Eq + Send + Sync + 'static {
     /// Returns the hash of the input.
     fn new(code: u64, input: &[u8]) -> Result<Self, Error>;
@@ -16,7 +17,7 @@ pub trait MultihashDigest: Clone + Debug + Eq + Send + Sync + 'static {
     /// Returns the code of the multihash.
     fn code(&self) -> u64;
 
-    /// Returns the size of the digest.
+    /// Returns the actual size of the digest, that will be returned by `digest()`.
     fn size(&self) -> u8;
 
     /// Returns the digest.

--- a/src/multihash_impl.rs
+++ b/src/multihash_impl.rs
@@ -1,4 +1,3 @@
-//! Default Code and Multihash implementation.
 use crate::hasher::Hasher;
 use crate::multihash::MultihashDigest;
 use multihash_derive::Multihash;
@@ -40,7 +39,12 @@ pub const STROBE_256: u64 = 0xa0;
 /// Multihash code for STROBE-512.
 pub const STROBE_512: u64 = 0xa1;
 
-/// An implementation of Multihash.
+/// Default Multihash implementation.
+///
+/// This is a default set of hashing algorithms. Usually applications would use their own subset of
+/// algorithms. See the [`Multihash` derive] for more information.
+///
+/// [`Multihash` derive]: crate::derive
 #[derive(Clone, Debug, Eq, Multihash, PartialEq)]
 pub enum Multihash {
     /// Multihash array for hash function.


### PR DESCRIPTION
Sadly I can't get the example in `derive/src/lib.rs` compile due to not having the `std` feature set.