### PR TITLE
Compat substrate hasher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ multihash-impl = ["derive", "all"]
 derive = ["tiny-multihash-derive"]
 test = ["multihash-impl", "quickcheck", "rand"]
 all = ["blake2b", "blake2s", "sha1", "sha2", "sha3", "strobe"]
+scale-codec = ["parity-scale-codec"]
 
 blake2b = ["blake2b_simd"]
 blake2s = ["blake2s_simd"]
@@ -38,6 +39,7 @@ unsigned-varint = { version = "0.5.0" }
 blake2b_simd = { version = "0.5.10", default-features = false, optional = true }
 blake2s_simd = { version = "0.5.10", default-features = false, optional = true }
 digest = { version = "0.9.0", default-features = false, optional = true }
+parity-scale-codec = { version = "1.3.4", optional = true, features = ["derive"] }
 sha-1 = { version = "0.9.1", default-features = false, optional = true }
 sha-2 = { version = "0.9.0", default-features = false, optional = true, package = "sha2" }
 sha-3 = { version = "0.9.0", default-features = false, optional = true, package = "sha3" }

--- a/benches/multihash.rs
+++ b/benches/multihash.rs
@@ -1,10 +1,10 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::Rng;
 
-use multihash::{
+use tiny_multihash::{
     Blake2b256, Blake2b512, Blake2s128, Blake2s256, Hasher, Keccak224, Keccak256, Keccak384,
-    Keccak512, Sha1, Sha2_256, Sha2_512, Sha3_224, Sha3_256, Sha3_384, Sha3_512, Strobe256,
-    Strobe512,
+    Keccak512, Sha1, Sha2_256, Sha2_512, Sha3_224, Sha3_256, Sha3_384, Sha3_512, StatefulHasher,
+    Strobe256, Strobe512,
 };
 
 macro_rules! group_digest {

--- a/derive/src/multihash.rs
+++ b/derive/src/multihash.rs
@@ -16,7 +16,7 @@ mod kw {
 #[derive(Debug)]
 enum MhAttr {
     Code(utils::Attr<kw::code, syn::Path>),
-    Hasher(utils::Attr<kw::hasher, syn::Path>),
+    Hasher(utils::Attr<kw::hasher, Box<syn::Type>>),
 }
 
 impl Parse for MhAttr {
@@ -38,7 +38,7 @@ struct Params {
 struct Hash {
     ident: syn::Ident,
     code: syn::Path,
-    hasher: syn::Path,
+    hasher: Box<syn::Type>,
     digest: syn::Path,
 }
 
@@ -237,11 +237,11 @@ mod tests {
         let input = quote! {
            #[derive(Clone, Multihash)]
            pub enum Multihash {
-               #[mh(code = multihash::IDENTITY, hasher = multihash::Identity256)]
-               Identity256(multihash::IdentityDigest<U32>),
+               #[mh(code = tiny_multihash::IDENTITY, hasher = tiny_multihash::Identity256)]
+               Identity256(tiny_multihash::IdentityDigest<U32>),
                /// Multihash array for hash function.
-               #[mh(code = multihash::STROBE_256, hasher = multihash::Strobe256)]
-               Strobe256(multihash::StrobeDigest<U32>),
+               #[mh(code = tiny_multihash::STROBE_256, hasher = tiny_multihash::Strobe256)]
+               Strobe256(tiny_multihash::StrobeDigest<U32>),
             }
         };
         let expected = quote! {
@@ -250,31 +250,31 @@ mod tests {
                     mh.code()
                 }
             }
-            impl multihash::MultihashDigest for Multihash {
-                fn new(code: u64, input: &[u8]) -> Result<Self, multihash::Error> {
+            impl tiny_multihash::MultihashDigest for Multihash {
+                fn new(code: u64, input: &[u8]) -> Result<Self, tiny_multihash::Error> {
                     match code {
-                        multihash::IDENTITY => Ok(Self::Identity256(multihash::Identity256::digest(input))),
-                        multihash::STROBE_256 => Ok(Self::Strobe256(multihash::Strobe256::digest(input))),
-                        _ => Err(multihash::Error::UnsupportedCode(code)),
+                        tiny_multihash::IDENTITY => Ok(Self::Identity256(tiny_multihash::Identity256::digest(input))),
+                        tiny_multihash::STROBE_256 => Ok(Self::Strobe256(tiny_multihash::Strobe256::digest(input))),
+                        _ => Err(tiny_multihash::Error::UnsupportedCode(code)),
                     }
                 }
-                fn wrap(code: u64, digest: &[u8]) -> Result<Self, multihash::Error> {
+                fn wrap(code: u64, digest: &[u8]) -> Result<Self, tiny_multihash::Error> {
                     match code {
-                        multihash::IDENTITY => Ok(Self::Identity256(multihash::Digest::wrap(digest)?)),
-                        multihash::STROBE_256 => Ok(Self::Strobe256(multihash::Digest::wrap(digest)?)),
-                        _ => Err(multihash::Error::UnsupportedCode(code)),
+                        tiny_multihash::IDENTITY => Ok(Self::Identity256(tiny_multihash::Digest::wrap(digest)?)),
+                        tiny_multihash::STROBE_256 => Ok(Self::Strobe256(tiny_multihash::Digest::wrap(digest)?)),
+                        _ => Err(tiny_multihash::Error::UnsupportedCode(code)),
                     }
                 }
                 fn code(&self) -> u64 {
                     match self {
-                        Multihash::Identity256(_mh) => multihash::IDENTITY,
-                        Multihash::Strobe256(_mh) => multihash::STROBE_256,
+                        Multihash::Identity256(_mh) => tiny_multihash::IDENTITY,
+                        Multihash::Strobe256(_mh) => tiny_multihash::STROBE_256,
                     }
                 }
                 fn size(&self) -> u8 {
                     match self {
-                        Multihash::Identity256(_mh) => multihash::Identity256::size(),
-                        Multihash::Strobe256(_mh) => multihash::Strobe256::size(),
+                        Multihash::Identity256(_mh) => tiny_multihash::Identity256::size(),
+                        Multihash::Strobe256(_mh) => tiny_multihash::Strobe256::size(),
                     }
                 }
                 fn digest(&self) -> &[u8] {
@@ -284,25 +284,25 @@ mod tests {
                     }
                 }
                 #[cfg(feature = "std")]
-                fn read<R: std::io::Read>(mut r: R) -> Result<Self, multihash::Error>
+                fn read<R: std::io::Read>(mut r: R) -> Result<Self, tiny_multihash::Error>
                 where
                     Self: Sized
                 {
-                    let code = multihash::read_code(&mut r)?;
+                    let code = tiny_multihash::read_code(&mut r)?;
                     match code {
-                        multihash::IDENTITY => Ok(Self::Identity256(multihash::read_digest(r)?)),
-                        multihash::STROBE_256 => Ok(Self::Strobe256(multihash::read_digest(r)?)),
-                        _ => Err(multihash::Error::UnsupportedCode(code)),
+                        tiny_multihash::IDENTITY => Ok(Self::Identity256(tiny_multihash::read_digest(r)?)),
+                        tiny_multihash::STROBE_256 => Ok(Self::Strobe256(tiny_multihash::read_digest(r)?)),
+                        _ => Err(tiny_multihash::Error::UnsupportedCode(code)),
                     }
                 }
             }
-            impl From<multihash::IdentityDigest<U32> > for Multihash {
-                fn from(digest: multihash::IdentityDigest<U32>) -> Self {
+            impl From<tiny_multihash::IdentityDigest<U32> > for Multihash {
+                fn from(digest: tiny_multihash::IdentityDigest<U32>) -> Self {
                     Self::Identity256(digest)
                 }
             }
-            impl From<multihash::StrobeDigest<U32> > for Multihash {
-                fn from(digest: multihash::StrobeDigest<U32>) -> Self {
+            impl From<tiny_multihash::StrobeDigest<U32> > for Multihash {
+                fn from(digest: tiny_multihash::StrobeDigest<U32>) -> Self {
                     Self::Strobe256(digest)
                 }
             }

--- a/derive/src/multihash.rs
+++ b/derive/src/multihash.rs
@@ -53,8 +53,8 @@ impl Hash {
     fn digest_size(&self, params: &Params) -> TokenStream {
         let ident = &self.ident;
         let mh_enum = &params.mh_enum;
-        let hasher = &self.hasher;
-        quote!(#mh_enum::#ident(_mh) => #hasher::size())
+        let mh = &params.mh_crate;
+        quote!(#mh_enum::#ident(mh) => #mh::Digest::size(mh))
     }
 
     fn digest_digest(&self, params: &Params) -> TokenStream {
@@ -273,8 +273,8 @@ mod tests {
                 }
                 fn size(&self) -> u8 {
                     match self {
-                        Multihash::Identity256(_mh) => tiny_multihash::Identity256::size(),
-                        Multihash::Strobe256(_mh) => tiny_multihash::Strobe256::size(),
+                        Multihash::Identity256(mh) => tiny_multihash::Digest::size(mh),
+                        Multihash::Strobe256(mh) => tiny_multihash::Digest::size(mh),
                     }
                 }
                 fn digest(&self) -> &[u8] {

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -29,6 +29,11 @@ pub trait Digest<S: Size>:
     + Sync
     + 'static
 {
+    /// Size of the digest.
+    fn size(&self) -> u8 {
+        S::to_u8()
+    }
+
     /// Wraps the digest bytes.
     fn wrap(digest: &[u8]) -> Result<Self, Error> {
         if digest.len() != S::to_u8() as _ {

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -34,8 +34,30 @@ pub trait Digest<S: Size>:
         if digest.len() != S::to_u8() as _ {
             return Err(Error::InvalidSize(digest.len() as _));
         }
+        Self::fit(digest)
+    }
+
+    /// Extends the digest size to the required size.
+    fn extend(digest: &[u8]) -> Result<Self, Error> {
+        if digest.len() > S::to_u8() as _ {
+            return Err(Error::InvalidSize(digest.len() as _));
+        }
+        Self::fit(digest)
+    }
+
+    /// Wraps and the digest bytes.
+    fn truncate(digest: &[u8]) -> Result<Self, Error> {
+        if digest.len() < S::to_u8() as _ {
+            return Err(Error::InvalidSize(digest.len() as _));
+        }
+        Self::fit(digest)
+    }
+
+    /// Fit the digest bytes.
+    fn fit(digest: &[u8]) -> Result<Self, Error> {
         let mut array = GenericArray::default();
-        array.copy_from_slice(digest);
+        let len = digest.len().min(array.len());
+        array[..len].copy_from_slice(&digest[..len]);
         Ok(array.into())
     }
 }

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -4,16 +4,18 @@ use generic_array::typenum::marker_traits::Unsigned;
 use generic_array::{ArrayLength, GenericArray};
 
 /// Size marker trait.
-pub trait Size: ArrayLength<u8> + Debug + Default + Eq + Send + Sync + 'static {}
+pub trait Size: ArrayLength<u8> + Debug + Default + Eq + core::hash::Hash + Send + Sync + 'static {}
 
-impl<T: ArrayLength<u8> + Debug + Default + Eq + Send + Sync + 'static> Size for T {}
+impl<T: ArrayLength<u8> + Debug + Default + Eq + core::hash::Hash + Send + Sync + 'static> Size for T {}
 
 /// Stack allocated digest trait.
 pub trait Digest<S: Size>:
     AsRef<[u8]>
+    + AsMut<[u8]>
     + From<GenericArray<u8, S>>
     + Into<GenericArray<u8, S>>
     + Clone
+    + core::hash::Hash
     + Debug
     + Default
     + Eq
@@ -55,7 +57,7 @@ pub trait Digest<S: Size>:
 /// [Multihashes]: https://github.com/multiformats/multihash
 /// [associated type]: https://doc.rust-lang.org/book/ch19-03-advanced-traits.html#specifying-placeholder-types-in-trait-definitions-with-associated-types
 /// [`MultihashDigest`]: crate::MultihashDigest
-pub trait Hasher: Default {
+pub trait Hasher: Default + Send + Sync {
     /// The maximum Digest size for that hasher (it is stack allocated).
     type Size: Size;
 

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -34,7 +34,7 @@ pub trait Digest<S: Size>:
         if digest.len() != S::to_u8() as _ {
             return Err(Error::InvalidSize(digest.len() as _));
         }
-        Self::fit(digest)
+        Ok(Self::fit(digest))
     }
 
     /// Extends the digest size to the required size.
@@ -42,7 +42,7 @@ pub trait Digest<S: Size>:
         if digest.len() > S::to_u8() as _ {
             return Err(Error::InvalidSize(digest.len() as _));
         }
-        Self::fit(digest)
+        Ok(Self::fit(digest))
     }
 
     /// Wraps and the digest bytes.
@@ -50,15 +50,15 @@ pub trait Digest<S: Size>:
         if digest.len() < S::to_u8() as _ {
             return Err(Error::InvalidSize(digest.len() as _));
         }
-        Self::fit(digest)
+        Ok(Self::fit(digest))
     }
 
     /// Fit the digest bytes.
-    fn fit(digest: &[u8]) -> Result<Self, Error> {
+    fn fit(digest: &[u8]) -> Self {
         let mut array = GenericArray::default();
         let len = digest.len().min(array.len());
         array[..len].copy_from_slice(&digest[..len]);
-        Ok(array.into())
+        array.into()
     }
 }
 

--- a/src/hasher_impl.rs
+++ b/src/hasher_impl.rs
@@ -1,4 +1,4 @@
-use crate::hasher::{Digest, Hasher, Size};
+use crate::hasher::{Digest, Size, StatefulHasher};
 use generic_array::GenericArray;
 
 macro_rules! derive_digest {
@@ -7,10 +7,7 @@ macro_rules! derive_digest {
         #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
         pub struct $name<S: Size>(GenericArray<u8, S>);
 
-        impl<S: Size> Copy for $name<S>
-        where
-            S::ArrayType: Copy,
-        {}
+        impl<S: Size> Copy for $name<S> where S::ArrayType: Copy {}
 
         impl<S: Size> AsRef<[u8]> for $name<S> {
             fn as_ref(&self) -> &[u8] {
@@ -48,7 +45,9 @@ macro_rules! derive_digest {
         //where
         //    S::ArrayType: parity_scale_codec::Decode + Into<GenericArray<u8, S>>,
         {
-            fn decode<I: parity_scale_codec::Input>(input: &mut I) -> Result<Self, parity_scale_codec::Error> {
+            fn decode<I: parity_scale_codec::Input>(
+                input: &mut I,
+            ) -> Result<Self, parity_scale_codec::Error> {
                 Ok(Self(<[u8; 32]>::decode(input)?.into()))
             }
         }
@@ -80,7 +79,7 @@ macro_rules! derive_hasher_blake {
             }
         }
 
-        impl<S: Size> Hasher for $name<S> {
+        impl<S: Size> StatefulHasher for $name<S> {
             type Size = S;
             type Digest = $digest<Self::Size>;
 
@@ -140,7 +139,7 @@ macro_rules! derive_hasher_sha {
             state: $module,
         }
 
-        impl $crate::hasher::Hasher for $name {
+        impl $crate::hasher::StatefulHasher for $name {
             type Size = $size;
             type Digest = $digest<Self::Size>;
 
@@ -212,7 +211,7 @@ pub mod identity {
         i: usize,
     }
 
-    impl<S: Size> Hasher for IdentityHasher<S> {
+    impl<S: Size> StatefulHasher for IdentityHasher<S> {
         type Size = S;
         type Digest = IdentityDigest<Self::Size>;
 
@@ -268,7 +267,7 @@ pub mod strobe {
         }
     }
 
-    impl<S: Size> Hasher for StrobeHasher<S> {
+    impl<S: Size> StatefulHasher for StrobeHasher<S> {
         type Size = S;
         type Digest = StrobeDigest<Self::Size>;
 

--- a/src/hasher_impl.rs
+++ b/src/hasher_impl.rs
@@ -41,14 +41,14 @@ macro_rules! derive_digest {
         }
 
         #[cfg(feature = "scale-codec")]
-        impl parity_scale_codec::Decode for $name<crate::U32>
-        //where
-        //    S::ArrayType: parity_scale_codec::Decode + Into<GenericArray<u8, S>>,
-        {
+        impl parity_scale_codec::Decode for $name<$crate::U64> {
             fn decode<I: parity_scale_codec::Input>(
                 input: &mut I,
             ) -> Result<Self, parity_scale_codec::Error> {
-                Ok(Self(<[u8; 32]>::decode(input)?.into()))
+                let digest = <[u8; 64]>::decode(input)?;
+                let mut array = GenericArray::default();
+                array.copy_from_slice(&digest[..]);
+                Ok(Self(array))
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub use crate::hasher::{Digest, Hasher, Size, StatefulHasher};
 #[cfg(feature = "std")]
 pub use crate::multihash::{read_code, read_digest};
 pub use crate::multihash::{MultihashDigest, RawMultihash};
-pub use generic_array::typenum::{self, U16, U20, U28, U32, U48, U64};
+pub use generic_array::typenum::{self, U128, U16, U20, U28, U32, U48, U64};
 #[cfg(feature = "derive")]
 pub use tiny_multihash_derive as derive;
 
@@ -63,7 +63,7 @@ pub use crate::multihash_impl::{
 pub use crate::hasher_impl::blake2b::{Blake2b256, Blake2b512, Blake2bDigest, Blake2bHasher};
 #[cfg(feature = "blake2s")]
 pub use crate::hasher_impl::blake2s::{Blake2s128, Blake2s256, Blake2sDigest, Blake2sHasher};
-pub use crate::hasher_impl::identity::{Identity256, IdentityDigest, IdentityHasher};
+pub use crate::hasher_impl::identity::{Identity, IdentityDigest, IdentityHasher};
 #[cfg(feature = "sha1")]
 pub use crate::hasher_impl::sha1::{Sha1, Sha1Digest};
 #[cfg(feature = "sha2")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ mod multihash_impl;
 pub use crate::error::{Error, Result};
 #[cfg(feature = "std")]
 pub use crate::hasher::WriteHasher;
-pub use crate::hasher::{Digest, Hasher, Size};
+pub use crate::hasher::{Digest, Hasher, Size, StatefulHasher};
 #[cfg(feature = "std")]
 pub use crate::multihash::{read_code, read_digest};
 pub use crate::multihash::{MultihashDigest, RawMultihash};

--- a/src/multihash.rs
+++ b/src/multihash.rs
@@ -211,11 +211,11 @@ where
     use unsigned_varint::io::read_u64;
 
     let size = read_u64(&mut r)?;
-    if size != S::to_u64() {
+    if size > S::to_u64() || size > u8::MAX as u64 {
         return Err(Error::InvalidSize(size));
     }
     let mut digest = GenericArray::default();
-    r.read_exact(&mut digest)?;
+    r.read_exact(&mut digest[..size as usize])?;
     Ok(D::from(digest))
 }
 

--- a/src/multihash.rs
+++ b/src/multihash.rs
@@ -81,6 +81,8 @@ pub trait MultihashDigest: Clone + Debug + Eq + Send + Sync + 'static {
 /// assert_eq!(mh.digest(), &digest_bytes[2..]);
 /// ```
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "scale-codec", derive(parity_scale_codec::Decode))]
+#[cfg_attr(feature = "scale-codec", derive(parity_scale_codec::Encode))]
 pub struct RawMultihash {
     /// The code of the Multihash.
     code: u64,

--- a/src/multihash_impl.rs
+++ b/src/multihash_impl.rs
@@ -113,7 +113,7 @@ mod tests {
     #[test]
     fn test_hasher_256() {
         let digest = Strobe256::digest(b"hello world");
-        let hash = Multihash::from(digest.clone());
+        let hash = Multihash::from(digest);
         let hash2 = Multihash::new(STROBE_256, b"hello world").unwrap();
         assert_eq!(hash.code(), STROBE_256);
         assert_eq!(hash.size(), 32);
@@ -124,7 +124,7 @@ mod tests {
     #[test]
     fn test_hasher_512() {
         let digest = Strobe512::digest(b"hello world");
-        let hash = Multihash::from(digest.clone());
+        let hash = Multihash::from(digest);
         let hash2 = Multihash::new(STROBE_512, b"hello world").unwrap();
         assert_eq!(hash.code(), STROBE_512);
         assert_eq!(hash.size(), 64);

--- a/src/multihash_impl.rs
+++ b/src/multihash_impl.rs
@@ -39,7 +39,7 @@ pub const STROBE_256: u64 = 0xa0;
 /// Multihash code for STROBE-512.
 pub const STROBE_512: u64 = 0xa1;
 
-/// Default Multihash implementation.
+/// Default (cryptographically secure) Multihash implementation.
 ///
 /// This is a default set of hashing algorithms. Usually applications would use their own subset of
 /// algorithms. See the [`Multihash` derive] for more information.
@@ -47,12 +47,6 @@ pub const STROBE_512: u64 = 0xa1;
 /// [`Multihash` derive]: crate::derive
 #[derive(Clone, Debug, Eq, Multihash, PartialEq)]
 pub enum Multihash {
-    /// Multihash array for hash function.
-    #[mh(code = self::IDENTITY, hasher = crate::Identity)]
-    Identity256(crate::IdentityDigest<crate::U128>),
-    /// Multihash array for hash function.
-    #[mh(code = self::SHA1, hasher = crate::Sha1)]
-    Sha1(crate::Sha1Digest<crate::U20>),
     /// Multihash array for hash function.
     #[mh(code = self::SHA2_256, hasher = crate::Sha2_256)]
     Sha2_256(crate::Sha2Digest<crate::U32>),

--- a/src/multihash_impl.rs
+++ b/src/multihash_impl.rs
@@ -48,8 +48,8 @@ pub const STROBE_512: u64 = 0xa1;
 #[derive(Clone, Debug, Eq, Multihash, PartialEq)]
 pub enum Multihash {
     /// Multihash array for hash function.
-    #[mh(code = self::IDENTITY, hasher = crate::Identity256)]
-    Identity256(crate::IdentityDigest<crate::U32>),
+    #[mh(code = self::IDENTITY, hasher = crate::Identity)]
+    Identity256(crate::IdentityDigest<crate::U128>),
     /// Multihash array for hash function.
     #[mh(code = self::SHA1, hasher = crate::Sha1)]
     Sha1(crate::Sha1Digest<crate::U20>),

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,9 +1,9 @@
 use tiny_multihash::{
     Blake2b256, Blake2b512, Blake2s128, Blake2s256, Hasher, Identity256, Keccak224, Keccak256,
     Keccak384, Keccak512, Multihash, MultihashDigest, RawMultihash, Sha1, Sha2_256, Sha2_512,
-    Sha3_224, Sha3_256, Sha3_384, Sha3_512, BLAKE2B_256, BLAKE2B_512, BLAKE2S_128, BLAKE2S_256,
-    KECCAK_224, KECCAK_256, KECCAK_384, KECCAK_512, SHA1, SHA2_256, SHA2_512, SHA3_224, SHA3_256,
-    SHA3_384, SHA3_512,
+    Sha3_224, Sha3_256, Sha3_384, Sha3_512, StatefulHasher, BLAKE2B_256, BLAKE2B_512, BLAKE2S_128,
+    BLAKE2S_256, KECCAK_224, KECCAK_256, KECCAK_384, KECCAK_512, SHA1, SHA2_256, SHA2_512,
+    SHA3_224, SHA3_256, SHA3_384, SHA3_512,
 };
 
 /// Helper function to convert a hex-encoded byte array back into a bytearray

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,9 +1,9 @@
 use tiny_multihash::{
-    Blake2b256, Blake2b512, Blake2s128, Blake2s256, Hasher, Identity256, Keccak224, Keccak256,
+    Blake2b256, Blake2b512, Blake2s128, Blake2s256, Hasher, Identity, Keccak224, Keccak256,
     Keccak384, Keccak512, Multihash, MultihashDigest, RawMultihash, Sha1, Sha2_256, Sha2_512,
     Sha3_224, Sha3_256, Sha3_384, Sha3_512, StatefulHasher, BLAKE2B_256, BLAKE2B_512, BLAKE2S_128,
-    BLAKE2S_256, KECCAK_224, KECCAK_256, KECCAK_384, KECCAK_512, SHA1, SHA2_256, SHA2_512,
-    SHA3_224, SHA3_256, SHA3_384, SHA3_512,
+    BLAKE2S_256, IDENTITY, KECCAK_224, KECCAK_256, KECCAK_384, KECCAK_512, SHA1, SHA2_256,
+    SHA2_512, SHA3_224, SHA3_256, SHA3_384, SHA3_512,
 };
 
 /// Helper function to convert a hex-encoded byte array back into a bytearray
@@ -43,8 +43,8 @@ macro_rules! assert_encode {
 fn multihash_encode() {
     assert_encode! {
         // A hash with a length bigger than 0x80, hence needing 2 bytes to encode the length
-        //Identity256, b"abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz", "00a1016162636465666768696a6b6c6d6e6f707172737475767778797a206162636465666768696a6b6c6d6e6f707172737475767778797a206162636465666768696a6b6c6d6e6f707172737475767778797a206162636465666768696a6b6c6d6e6f707172737475767778797a206162636465666768696a6b6c6d6e6f707172737475767778797a206162636465666768696a6b6c6d6e6f707172737475767778797a";
-        //Identity256, b"beep boop", "00096265657020626f6f70";
+        //Identity, b"abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz", "00a1016162636465666768696a6b6c6d6e6f707172737475767778797a206162636465666768696a6b6c6d6e6f707172737475767778797a206162636465666768696a6b6c6d6e6f707172737475767778797a206162636465666768696a6b6c6d6e6f707172737475767778797a206162636465666768696a6b6c6d6e6f707172737475767778797a206162636465666768696a6b6c6d6e6f707172737475767778797a";
+        Identity, b"beep boop", "00096265657020626f6f70";
         Sha1, b"beep boop", "11147c8357577f51d4f0a8d393aa1aaafb28863d9421";
         Sha2_256, b"helloworld", "1220936a185caaa266bb9cbe981e9e05cb78cd732b0b3280eb944412bb6f8f8f07af";
         Sha2_256, b"beep boop", "122090ea688e275d580567325032492b597bc77221c62493e76330b85ddda191ef7c";
@@ -80,7 +80,7 @@ macro_rules! assert_decode {
 #[test]
 fn assert_decode() {
     assert_decode! {
-        //Identity256, "000a68656c6c6f776f726c64";
+        IDENTITY, "000a68656c6c6f776f726c64";
         SHA1, "11147c8357577f51d4f0a8d393aa1aaafb28863d9421";
         SHA2_256, "1220936a185caaa266bb9cbe981e9e05cb78cd732b0b3280eb944412bb6f8f8f07af";
         SHA2_256, "122090ea688e275d580567325032492b597bc77221c62493e76330b85ddda191ef7c";
@@ -127,20 +127,8 @@ macro_rules! assert_roundtrip {
 #[test]
 fn assert_roundtrip() {
     assert_roundtrip!(
-        Identity256,
-        Sha1,
-        Sha2_256,
-        Sha2_512,
-        Sha3_224,
-        Sha3_256,
-        Sha3_384,
-        Sha3_512,
-        Keccak224,
-        Keccak256,
-        Keccak384,
-        Keccak512,
-        Blake2b512,
-        Blake2s256
+        Identity, Sha1, Sha2_256, Sha2_512, Sha3_224, Sha3_256, Sha3_384, Sha3_512, Keccak224,
+        Keccak256, Keccak384, Keccak512, Blake2b512, Blake2s256
     );
 }
 /*
@@ -233,7 +221,7 @@ fn multihash_methods() {
 fn test_long_identity_hash() {
     // A hash with a length bigger than 0x80, hence needing 2 bytes to encode the length
     let input = b"abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz";
-    Identity256::digest(input);
+    Identity::digest(input);
 }
 
 #[test]
@@ -254,12 +242,12 @@ fn multihash_errors() {
         Multihash::from_bytes(&[0x12, 0x20, 0xff]).is_err(),
         "Should error on correct prefix with wrong digest"
     );
-    let identity_code: u8 = 0x00;
+    /*let identity_code: u8 = 0x00;
     let identity_length = 3;
     assert!(
         Multihash::from_bytes(&[identity_code, identity_length, 1, 2, 3, 4]).is_err(),
         "Should error on wrong hash length"
-    );
+    );*/
 }
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,10 +1,71 @@
 use tiny_multihash::{
-    Blake2b256, Blake2b512, Blake2s128, Blake2s256, Hasher, Identity, Keccak224, Keccak256,
-    Keccak384, Keccak512, Multihash, MultihashDigest, RawMultihash, Sha1, Sha2_256, Sha2_512,
-    Sha3_224, Sha3_256, Sha3_384, Sha3_512, StatefulHasher, BLAKE2B_256, BLAKE2B_512, BLAKE2S_128,
+    derive::Multihash, read_code, read_digest, Blake2b256, Blake2b512, Blake2bDigest, Blake2s128,
+    Blake2s256, Blake2sDigest, Digest, Error, Hasher, Identity, IdentityDigest, Keccak224,
+    Keccak256, Keccak384, Keccak512, KeccakDigest, MultihashDigest, RawMultihash, Sha1, Sha1Digest,
+    Sha2Digest, Sha2_256, Sha2_512, Sha3Digest, Sha3_224, Sha3_256, Sha3_384, Sha3_512,
+    StatefulHasher, Strobe256, Strobe512, StrobeDigest, BLAKE2B_256, BLAKE2B_512, BLAKE2S_128,
     BLAKE2S_256, IDENTITY, KECCAK_224, KECCAK_256, KECCAK_384, KECCAK_512, SHA1, SHA2_256,
-    SHA2_512, SHA3_224, SHA3_256, SHA3_384, SHA3_512,
+    SHA2_512, SHA3_224, SHA3_256, SHA3_384, SHA3_512, STROBE_256, STROBE_512, U128, U16, U20, U28,
+    U32, U48, U64,
 };
+
+#[derive(Clone, Debug, Eq, Multihash, PartialEq)]
+pub enum Multihash {
+    /// Multihash array for hash function.
+    #[mh(code = IDENTITY, hasher = Identity)]
+    Identity256(IdentityDigest<U128>),
+    /// Multihash array for hash function.
+    #[mh(code = SHA1, hasher = Sha1)]
+    Sha1(Sha1Digest<U20>),
+    /// Multihash array for hash function.
+    #[mh(code = SHA2_256, hasher = Sha2_256)]
+    Sha2_256(Sha2Digest<U32>),
+    /// Multihash array for hash function.
+    #[mh(code = SHA2_512, hasher = Sha2_512)]
+    Sha2_512(Sha2Digest<U64>),
+    /// Multihash array for hash function.
+    #[mh(code = SHA3_224, hasher = Sha3_224)]
+    Sha3_224(Sha3Digest<U28>),
+    /// Multihash array for hash function.
+    #[mh(code = SHA3_256, hasher = Sha3_256)]
+    Sha3_256(Sha3Digest<U32>),
+    /// Multihash array for hash function.
+    #[mh(code = SHA3_384, hasher = Sha3_384)]
+    Sha3_384(Sha3Digest<U48>),
+    /// Multihash array for hash function.
+    #[mh(code = SHA3_512, hasher = Sha3_512)]
+    Sha3_512(Sha3Digest<U64>),
+    /// Multihash array for hash function.
+    #[mh(code = KECCAK_224, hasher = Keccak224)]
+    Keccak224(KeccakDigest<U28>),
+    /// Multihash array for hash function.
+    #[mh(code = KECCAK_256, hasher = Keccak256)]
+    Keccak256(KeccakDigest<U32>),
+    /// Multihash array for hash function.
+    #[mh(code = KECCAK_384, hasher = Keccak384)]
+    Keccak384(KeccakDigest<U48>),
+    /// Multihash array for hash function.
+    #[mh(code = KECCAK_512, hasher = Keccak512)]
+    Keccak512(KeccakDigest<U64>),
+    /// Multihash array for hash function.
+    #[mh(code = BLAKE2B_256, hasher = Blake2b256)]
+    Blake2b256(Blake2bDigest<U32>),
+    /// Multihash array for hash function.
+    #[mh(code = BLAKE2B_512, hasher = Blake2b512)]
+    Blake2b512(Blake2bDigest<U64>),
+    /// Multihash array for hash function.
+    #[mh(code = BLAKE2S_128, hasher = Blake2s128)]
+    Blake2s128(Blake2sDigest<U16>),
+    /// Multihash array for hash function.
+    #[mh(code = BLAKE2S_256, hasher = Blake2s256)]
+    Blake2s256(Blake2sDigest<U32>),
+    /// Multihash array for hash function.
+    #[mh(code = STROBE_256, hasher = Strobe256)]
+    Strobe256(StrobeDigest<U32>),
+    /// Multihash array for hash function.
+    #[mh(code = STROBE_512, hasher = Strobe512)]
+    Strobe512(StrobeDigest<U64>),
+}
 
 /// Helper function to convert a hex-encoded byte array back into a bytearray
 fn hex_to_bytes(s: &str) -> Vec<u8> {


### PR DESCRIPTION
Adds some trait bounds to be compatible with the substrate hasher trait (it can be implemented for a multihash), and split the Hasher trait #9 