### PR TITLE
fix: make the std feature work smoother

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT"
 
 [features]
 default = ["std", "all", "derive", "multihash-impl", "scale-codec", "serde-codec"]
-std = ["unsigned-varint/std"]
+std = ["unsigned-varint/std", "tiny-multihash-derive/std"]
 multihash-impl = ["derive", "all"]
 derive = ["tiny-multihash-derive"]
 test = ["multihash-impl", "quickcheck", "rand"]
@@ -36,7 +36,7 @@ parity-scale-codec = { version = "1.3.4", optional = true, default-features = fa
 quickcheck = { version = "0.9.2", optional = true }
 rand = { version = "0.7.3", optional = true }
 serde = { version = "1.0.115", optional = true, default-features = false, features = ["derive"] }
-tiny-multihash-derive = { version = "0.4.0", path = "derive", optional = true }
+tiny-multihash-derive = { version = "0.4.0", path = "derive", default-features = false, optional = true }
 unsigned-varint = "0.5.0"
 
 blake2b_simd = { version = "0.5.10", default-features = false, optional = true }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -18,6 +18,10 @@ quote = "1.0.7"
 syn = "1.0.39"
 synstructure = "0.12.4"
 
+[features]
+default = ["std"]
+std = []
+
 [dev-dependencies]
 pretty_assertions = "0.6.1"
 tiny-multihash = { path = "..", default-features = false }

--- a/src/multihash.rs
+++ b/src/multihash.rs
@@ -1,5 +1,6 @@
 use crate::error::Error;
 use crate::hasher::Digest;
+#[cfg(feature = "std")]
 use core::convert::TryInto;
 use core::fmt::Debug;
 


### PR DESCRIPTION
It is now possible to use the tiny-multihash Multihash derive, even
if the crate that has tiny-multihash doesn't have a std feature.

I don't know if it really does the right thing. I think it does, it seems to work as expected when I tried this locally, but I have almost no experience with no_std.