### PR TITLE
fix: make scale-codec and serde non-default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["multihash", "ipfs"]
 license = "MIT"
 
 [features]
-default = ["std", "all", "derive", "multihash-impl", "scale-codec", "serde-codec"]
+default = ["std", "all", "derive", "multihash-impl"]
 std = ["unsigned-varint/std", "tiny-multihash-derive/std"]
 multihash-impl = ["derive", "all"]
 derive = ["tiny-multihash-derive"]


### PR DESCRIPTION
To me the scale codec and the serde serialization seem special purpose, so I'd like to have them behind features and not enabled by default.

I decided to just do a PR instead of opening an issue, to move faster (and as it was simple), though this is meant for further discssion, as I might miss some points why it makes sense to have them enabled by default.