### PR TITLE
fix: remove Strobe hasher from default hashers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ pub use tiny_multihash_derive as derive;
 pub use crate::multihash_impl::{
     Multihash, BLAKE2B_256, BLAKE2B_512, BLAKE2S_128, BLAKE2S_256, IDENTITY, KECCAK_224,
     KECCAK_256, KECCAK_384, KECCAK_512, SHA1, SHA2_256, SHA2_512, SHA3_224, SHA3_256, SHA3_384,
-    SHA3_512, STROBE_256, STROBE_512,
+    SHA3_512,
 };
 
 #[cfg(feature = "blake2b")]

--- a/src/multihash.rs
+++ b/src/multihash.rs
@@ -277,12 +277,12 @@ where
 mod tests {
     use super::*;
     use crate::hasher::Hasher;
-    use crate::hasher_impl::strobe::Strobe256;
+    use crate::hasher_impl::sha2::Sha2_256;
     use crate::multihash_impl::Multihash;
 
     #[test]
     fn roundtrip() {
-        let digest = Strobe256::digest(b"hello world");
+        let digest = Sha2_256::digest(b"hello world");
         let hash = Multihash::from(digest);
         let mut buf = [0u8; 35];
         hash.write(&mut buf[..]).unwrap();

--- a/src/multihash_impl.rs
+++ b/src/multihash_impl.rs
@@ -34,10 +34,6 @@ pub const BLAKE2B_512: u64 = 0xb240;
 pub const BLAKE2S_128: u64 = 0xb250;
 /// Multihash code for BLAKE2s-256.
 pub const BLAKE2S_256: u64 = 0xb260;
-/// Multihash code for STROBE-256.
-pub const STROBE_256: u64 = 0xa0;
-/// Multihash code for STROBE-512.
-pub const STROBE_512: u64 = 0xa1;
 
 /// Default (cryptographically secure) Multihash implementation.
 ///
@@ -89,27 +85,21 @@ pub enum Multihash {
     /// Multihash array for hash function.
     #[mh(code = self::BLAKE2S_256, hasher = crate::Blake2s256)]
     Blake2s256(crate::Blake2sDigest<crate::U32>),
-    /// Multihash array for hash function.
-    #[mh(code = self::STROBE_256, hasher = crate::Strobe256)]
-    Strobe256(crate::StrobeDigest<crate::U32>),
-    /// Multihash array for hash function.
-    #[mh(code = self::STROBE_512, hasher = crate::Strobe512)]
-    Strobe512(crate::StrobeDigest<crate::U64>),
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::hasher::Hasher;
-    use crate::hasher_impl::strobe::{Strobe256, Strobe512};
+    use crate::hasher_impl::sha3::{Sha3_256, Sha3_512};
     use crate::multihash::MultihashDigest;
 
     #[test]
     fn test_hasher_256() {
-        let digest = Strobe256::digest(b"hello world");
+        let digest = Sha3_256::digest(b"hello world");
         let hash = Multihash::from(digest);
-        let hash2 = Multihash::new(STROBE_256, b"hello world").unwrap();
-        assert_eq!(hash.code(), STROBE_256);
+        let hash2 = Multihash::new(SHA3_256, b"hello world").unwrap();
+        assert_eq!(hash.code(), SHA3_256);
         assert_eq!(hash.size(), 32);
         assert_eq!(hash.digest(), digest.as_ref());
         assert_eq!(hash, hash2);
@@ -117,10 +107,10 @@ mod tests {
 
     #[test]
     fn test_hasher_512() {
-        let digest = Strobe512::digest(b"hello world");
+        let digest = Sha3_512::digest(b"hello world");
         let hash = Multihash::from(digest);
-        let hash2 = Multihash::new(STROBE_512, b"hello world").unwrap();
-        assert_eq!(hash.code(), STROBE_512);
+        let hash2 = Multihash::new(SHA3_512, b"hello world").unwrap();
+        assert_eq!(hash.code(), SHA3_512);
         assert_eq!(hash.size(), 64);
         assert_eq!(hash.digest(), digest.as_ref());
         assert_eq!(hash, hash2);

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -5,9 +5,11 @@ use tiny_multihash::{
     Sha2Digest, Sha2_256, Sha2_512, Sha3Digest, Sha3_224, Sha3_256, Sha3_384, Sha3_512,
     StatefulHasher, Strobe256, Strobe512, StrobeDigest, BLAKE2B_256, BLAKE2B_512, BLAKE2S_128,
     BLAKE2S_256, IDENTITY, KECCAK_224, KECCAK_256, KECCAK_384, KECCAK_512, SHA1, SHA2_256,
-    SHA2_512, SHA3_224, SHA3_256, SHA3_384, SHA3_512, STROBE_256, STROBE_512, U128, U16, U20, U28,
-    U32, U48, U64,
+    SHA2_512, SHA3_224, SHA3_256, SHA3_384, SHA3_512, U128, U16, U20, U28, U32, U48, U64,
 };
+
+const STROBE_256: u64 = 0x3312e7;
+const STROBE_512: u64 = 0x3312e8;
 
 #[derive(Clone, Debug, Eq, Multihash, PartialEq)]
 pub enum Multihash {


### PR DESCRIPTION
The Strobe hasher doesn't have a Multicodec code assigned, hence remove
it from the default list of hashers.

Closed #21.