### PR TITLE
fix: fix identity hash from Digest calls

### DIFF
--- a/derive/src/multihash.rs
+++ b/derive/src/multihash.rs
@@ -82,7 +82,7 @@ impl Hash {
         let code = &self.code;
         let ident = &self.ident;
         let mh = &params.mh_crate;
-        quote!(#code => Ok(Self::#ident(#mh::read_digest(r)?)))
+        quote!(#code => Ok(Self::#ident(#mh::Digest::from_reader(r)?)))
     }
 
     fn from_digest(&self, params: &Params) -> TokenStream {
@@ -179,7 +179,7 @@ pub fn multihash(s: Structure) -> TokenStream {
             where
                Self: Sized
             {
-               let code = #mh_crate::read_code(&mut r)?;
+               let code = unsigned_varint::io::read_u64(&mut r)?;
                match code {
                    #(#digest_read,)*
                    _ => Err(#mh_crate::Error::UnsupportedCode(code)),
@@ -296,10 +296,10 @@ mod tests {
                 where
                     Self: Sized
                 {
-                    let code = tiny_multihash::read_code(&mut r)?;
+                    let code = unsigned_varint::io::read_u64(&mut r)?;
                     match code {
-                        tiny_multihash::IDENTITY => Ok(Self::Identity256(tiny_multihash::read_digest(r)?)),
-                        tiny_multihash::STROBE_256 => Ok(Self::Strobe256(tiny_multihash::read_digest(r)?)),
+                        tiny_multihash::IDENTITY => Ok(Self::Identity256(tiny_multihash::Digest::from_reader(r)?)),
+                        tiny_multihash::STROBE_256 => Ok(Self::Strobe256(tiny_multihash::Digest::from_reader(r)?)),
                         _ => Err(tiny_multihash::Error::UnsupportedCode(code)),
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,6 @@ pub use crate::error::{Error, Result};
 #[cfg(feature = "std")]
 pub use crate::hasher::WriteHasher;
 pub use crate::hasher::{Digest, Hasher, Size, StatefulHasher};
-#[cfg(feature = "std")]
-pub use crate::multihash::{read_code, read_digest};
 pub use crate::multihash::{MultihashDigest, RawMultihash};
 pub use generic_array::typenum::{self, U128, U16, U20, U28, U32, U48, U64};
 #[cfg(feature = "derive")]

--- a/src/multihash.rs
+++ b/src/multihash.rs
@@ -77,6 +77,8 @@ pub trait MultihashDigest: Clone + Debug + Eq + Send + Sync + 'static {
 /// With this Multihash implementation you can operate on Multihashes in a generic way, but
 /// no hasher implementation is associated with the code.
 ///
+/// The maximum size is currently 512 Bit.
+///
 /// # Example
 ///
 /// ```
@@ -211,38 +213,6 @@ where
     w.write_all(size)?;
     w.write_all(digest)?;
     Ok(())
-}
-
-/// Reads a code from a byte stream.
-#[cfg(feature = "std")]
-pub fn read_code<R>(mut r: R) -> Result<u64, Error>
-where
-    R: std::io::Read,
-{
-    use unsigned_varint::io::read_u64;
-    Ok(read_u64(&mut r)?)
-}
-
-/// Reads a multihash from a byte stream that contains the digest prefixed with the size.
-///
-/// The byte stream must not contain the code as prefix.
-#[cfg(feature = "std")]
-pub fn read_digest<R, S, D>(mut r: R) -> Result<D, Error>
-where
-    R: std::io::Read,
-    S: crate::hasher::Size,
-    D: crate::hasher::Digest<S>,
-{
-    use generic_array::GenericArray;
-    use unsigned_varint::io::read_u64;
-
-    let size = read_u64(&mut r)?;
-    if size > S::to_u64() || size > u8::MAX as u64 {
-        return Err(Error::InvalidSize(size));
-    }
-    let mut digest = GenericArray::default();
-    r.read_exact(&mut digest[..size as usize])?;
-    Ok(D::from(digest))
 }
 
 /// Reads a multihash from a byte stream that contains a full multihash (code, size and the digest)

--- a/tests/custom_table.rs
+++ b/tests/custom_table.rs
@@ -1,5 +1,5 @@
 use tiny_multihash::derive::Multihash;
-use tiny_multihash::{read_code, read_digest, Digest, Error, Hasher, MultihashDigest};
+use tiny_multihash::{Digest, Error, Hasher, MultihashDigest};
 
 const FOO: u64 = 0x01;
 const BAR: u64 = 0x02;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,7 +1,7 @@
 use tiny_multihash::{
-    derive::Multihash, read_code, read_digest, Blake2b256, Blake2b512, Blake2bDigest, Blake2s128,
-    Blake2s256, Blake2sDigest, Digest, Error, Hasher, Identity256, IdentityDigest, Keccak224,
-    Keccak256, Keccak384, Keccak512, KeccakDigest, MultihashDigest, RawMultihash, Sha1, Sha1Digest,
+    derive::Multihash, Blake2b256, Blake2b512, Blake2bDigest, Blake2s128, Blake2s256,
+    Blake2sDigest, Digest, Error, Hasher, Identity256, IdentityDigest, Keccak224, Keccak256,
+    Keccak384, Keccak512, KeccakDigest, MultihashDigest, RawMultihash, Sha1, Sha1Digest,
     Sha2Digest, Sha2_256, Sha2_512, Sha3Digest, Sha3_224, Sha3_256, Sha3_384, Sha3_512,
     StatefulHasher, Strobe256, Strobe512, StrobeDigest, BLAKE2B_256, BLAKE2B_512, BLAKE2S_128,
     BLAKE2S_256, IDENTITY, KECCAK_224, KECCAK_256, KECCAK_384, KECCAK_512, SHA1, SHA2_256,


### PR DESCRIPTION
The identity hash needs a size of the actual hash associated with the
digest, hence ut needs custom Digest trait implementations.