### PR TITLE
fix: derive: add error for dupplicated codes

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/ipfs-rust/tiny-multihash"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.19"
+proc-macro2 = { version = "1.0.19", features = ["span-locations"] }
 proc-macro-crate = "0.1.5"
 proc-macro-error = "1.0.4"
 quote = "1.0.7"


### PR DESCRIPTION
You will get an error if you use the same code for two different
hashers.