### PR TITLE
Allows selection of multihashes by name

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,8 @@ pub enum Error {
     Io(IoError),
     /// Unsupported multihash code.
     UnsupportedCode(u64),
+    /// Unsupported multihash name.
+    UnsupportedName(String),
     /// Invalid multihash size.
     InvalidSize(u64),
     /// Invalid varint.
@@ -24,6 +26,7 @@ impl core::fmt::Display for Error {
             #[cfg(feature = "std")]
             Self::Io(err) => write!(f, "{}", err),
             Self::UnsupportedCode(code) => write!(f, "Unsupported multihash code {}.", code),
+            Self::UnsupportedName(name) => write!(f, "Unsupported multihash name {}.", name),
             Self::InvalidSize(size) => write!(f, "Invalid multihash size {}.", size),
             Self::Varint(err) => write!(f, "{}", err),
         }

--- a/src/multihash.rs
+++ b/src/multihash.rs
@@ -16,8 +16,17 @@ pub trait MultihashDigest: Clone + Debug + Eq + Send + Sync + 'static {
     /// Wraps the digest in a multihash.
     fn wrap(code: u64, digest: &[u8]) -> Result<Self, Error>;
 
+    /// Returns the hash of the input.
+    fn new_with_name(name: &str, input: &[u8]) -> Result<Self, Error>;
+
+    /// Wraps the digest in a multihash.
+    fn wrap_with_name(name: &str, digest: &[u8]) -> Result<Self, Error>;
+
     /// Returns the code of the multihash.
     fn code(&self) -> u64;
+
+    /// Returns the name of the multihash.
+    fn name(&self) -> &'static str;
 
     /// Returns the actual size of the digest, that will be returned by `digest()`.
     fn size(&self) -> u8;


### PR DESCRIPTION
Adds several new functions to the `Multihash` trait:
1. `Multihash::name(&self) -> &'static str`
2. `Multihash::new_with_name(name: &str, input: &[u8]) -> Result<Self, Error>`
3. `Multihash::wrap_with_name(name: &str, digest: &[u8]) -> Result<Self, Error>`

Together these functions create a (somewhat) nice interface for refering
to multihash hash algorithm variants by a more human-readable name.

Adds the `Error::UnsupportedName` variant to represent
invalid names in `Multihash::new_with_name` and
`Multihash::wrap_with_name`.

Adds the `#[mh(name = ...)]` attribute to the `Multihash` derive macro.
This allows the user to specify a custom name to associate with a given
hash algorithm variant. If this attribute is not specified, then the
stringified representation of the name of the variant corresponding to that hash
function will be used instead.

Adds nice error handeling & updated tests for the `#[mh(name)]`
attribute.

Resolves #32, although more work is probably needed for a full solution.