### PR TITLE
feat: derive from Code enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ derive = ["tiny-multihash-derive"]
 test = ["multihash-impl", "quickcheck", "rand"]
 all = ["blake2b", "blake2s", "sha1", "sha2", "sha3", "strobe"]
 scale-codec = ["parity-scale-codec"]
-serde-codec = ["serde"]
+serde-codec = ["serde", "generic-array/serde"]
 
 blake2b = ["blake2b_simd"]
 blake2s = ["blake2s_simd"]

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! ```
 //! use tiny_multihash::derive::Multihash;
-//! use tiny_multihash::{U32, U64};
+//! use tiny_multihash::{U32, U64, MultihashCode};
 //!
 //! #[derive(Clone, Debug, Eq, Multihash, PartialEq)]
 //! #[mh(max_size = U64)]

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! ```
 //! use tiny_multihash::derive::Multihash;
-//! use tiny_multihash::{Digest, Error, Hasher, Multihash, Size, U32, U64};
+//! use tiny_multihash::{U32, U64};
 //!
 //! #[derive(Clone, Debug, Eq, Multihash, PartialEq)]
 //! #[mh(max_size = U64)]

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,24 +1,32 @@
-//! This proc macro derives a [`MultihashDigest`] implementation from a list of hashers.
+//! This proc macro derives a custom Multihash code table from a list of hashers.
+//!
+//! The digests are stack allocated with a fixed size. That size needs to be big enough to hold any
+//! of the specified hash digests. This cannot be determined automatically on compile-time, hence
+//! it needs to set manually via the `max_size` attribute.
+//!
+//! If you set `#mh(max_size = …)` to a too low value, e.g. to `U32` in the example below, your
+//! hasher will panic when it tried to generate the `Sha2_512` hash. If you set it to a value
+//! larger than strictly needed, e.g. to `U128` in the example blow, it will use more memory, but
+//! it won't have any consequences on the correctness.
 //!
 //! # Example
 //!
-//! ```compile_fail
-//! use multihash::derive::Multihash;
-//! use multihash::{Hasher, MultihashDigest};
-//!
-//! const FOO: u64 = 0x01;
-//! const BAR: u64 = 0x02;
+//! ```
+//! use tiny_multihash::derive::Multihash;
+//! use tiny_multihash::{Digest, Error, Hasher, Multihash, Size, U32, U64};
 //!
 //! #[derive(Clone, Debug, Eq, Multihash, PartialEq)]
-//! pub enum Multihash {
-//!     #[mh(code = FOO, hasher = multihash::Sha2_256)]
-//!     Foo(multihash::Sha2Digest<multihash::U32>),
-//!     #[mh(code = BAR, hasher = multihash::Sha2_512)]
-//!     Bar(multihash::Sha2Digest<multihash::U64>),
+//! #[mh(max_size = U64)]
+//! pub enum Code {
+//!     #[mh(code = 0x01, hasher = tiny_multihash::Sha2_256, digest = tiny_multihash::Sha2Digest<U32>)]
+//!     Foo,
+//!     #[mh(code = 0x02, hasher = tiny_multihash::Sha2_512, digest = tiny_multihash::Sha2Digest<U64>)]
+//!     Bar,
 //! }
-//! ```
 //!
-//! [`MultihashDigest`]: ../multihash/trait.MultihashDigest.html
+//! let hash = Code::Foo.digest(b"hello world!");
+//! println!("{:02x?}", hash);
+//! ```
 extern crate proc_macro;
 
 mod multihash;

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -15,7 +15,7 @@
 //! use tiny_multihash::derive::Multihash;
 //! use tiny_multihash::{U32, U64, MultihashCode};
 //!
-//! #[derive(Clone, Debug, Eq, Multihash, PartialEq)]
+//! #[derive(Clone, Copy, Debug, Eq, Multihash, PartialEq)]
 //! #[mh(max_size = U64)]
 //! pub enum Code {
 //!     #[mh(code = 0x01, hasher = tiny_multihash::Sha2_256, digest = tiny_multihash::Sha2Digest<U32>)]

--- a/derive/src/multihash.rs
+++ b/derive/src/multihash.rs
@@ -227,38 +227,17 @@ pub fn multihash(s: Structure) -> TokenStream {
     let from_digest = hashes.iter().map(|h| h.from_digest(&params));
 
     quote! {
-        impl #code_enum {
-            /// Calculate the hash of some input data.
-            ///
-            /// # Example
-            ///
-            /// ```
-            /// use tiny_multihash::Code;
-            ///
-            /// let hash = Code::Sha3_256.digest(b"Hello world!");
-            /// println!("{:02x?}", hash);
-            /// ```
-            // TODO vmx 2020-09-21: Don't hardcode the size here, define it in the code enum
-            pub fn digest(&self, input: &[u8]) -> #mh_crate::Multihash<#max_size> {
+        impl #mh_crate::MultihashCode for #code_enum {
+            type MaxSize = #max_size;
+
+            fn digest(&self, input: &[u8]) -> #mh_crate::Multihash<Self::MaxSize> {
                 use #mh_crate::Hasher;
                 match self {
                     #(#code_digest,)*
                 }
             }
 
-            /// Create a multihash from an existing [`Digest`].
-            ///
-            /// # Example
-            ///
-            /// ```
-            /// use tiny_multihash::{Code, Sha3_256, StatefulHasher};
-            ///
-            /// let mut hasher = Sha3_256::default();
-            /// hasher.update(b"Hello world!");
-            /// let hash = Code::multihash_from_digest(&hasher.finalize());
-            /// println!("{:02x?}", hash);
-            /// ```
-            pub fn multihash_from_digest<'a, S, D>(digest: &'a D) -> #mh_crate::Multihash<#max_size>
+            fn multihash_from_digest<'a, S, D>(digest: &'a D) -> #mh_crate::Multihash<Self::MaxSize>
             where
                 S: #mh_crate::Size,
                 D: #mh_crate::Digest<S>,
@@ -310,18 +289,10 @@ mod tests {
             }
         };
         let expected = quote! {
-            impl Code {
-               /// Calculate the hash of some input data.
-               ///
-               /// # Example
-               ///
-               /// ```
-               /// use tiny_multihash::Code;
-               ///
-               /// let hash = Code::Sha3_256.digest(b"Hello world!");
-               /// println!("{:02x?}", hash);
-               /// ```
-               pub fn digest(&self, input: &[u8]) -> tiny_multihash::Multihash<U32> {
+            impl tiny_multihash::MultihashCode for Code {
+               type MaxSize = U32;
+
+               fn digest(&self, input: &[u8]) -> tiny_multihash::Multihash<Self::MaxSize> {
                    use tiny_multihash::Hasher;
                    match self {
                        Self::Identity256 => {
@@ -335,19 +306,7 @@ mod tests {
                    }
                }
 
-               /// Create a multihash from an existing [`Digest`].
-               ///
-               /// # Example
-               ///
-               /// ```
-               /// use tiny_multihash::{Code, Sha3_256, StatefulHasher};
-               ///
-               /// let mut hasher = Sha3_256::default();
-               /// hasher.update(b"Hello world!");
-               /// let hash = Code::multihash_from_digest(&hasher.finalize());
-               /// println!("{:02x?}", hash);
-               /// ```
-               pub fn multihash_from_digest<'a, S, D>(digest: &'a D) -> tiny_multihash::Multihash<U32>
+               fn multihash_from_digest<'a, S, D>(digest: &'a D) -> tiny_multihash::Multihash<Self::MaxSize>
                where
                    S: tiny_multihash::Size,
                    D: tiny_multihash::Digest<S>,

--- a/derive/src/multihash.rs
+++ b/derive/src/multihash.rs
@@ -239,7 +239,8 @@ pub fn multihash(s: Structure) -> TokenStream {
             /// println!("{:02x?}", hash);
             /// ```
             // TODO vmx 2020-09-21: Don't hardcode the size here, define it in the code enum
-            pub fn digest(&self, input: &[u8]) -> Multihash<#max_size> {
+            pub fn digest(&self, input: &[u8]) -> #mh_crate::Multihash<#max_size> {
+                use #mh_crate::Hasher;
                 match self {
                     #(#code_digest,)*
                 }
@@ -257,9 +258,9 @@ pub fn multihash(s: Structure) -> TokenStream {
             /// let hash = Code::multihash_from_digest(&hasher.finalize());
             /// println!("{:02x?}", hash);
             /// ```
-            pub fn multihash_from_digest<'a, S, D>(digest: &'a D) -> Multihash<#max_size>
+            pub fn multihash_from_digest<'a, S, D>(digest: &'a D) -> #mh_crate::Multihash<#max_size>
             where
-                S: Size,
+                S: #mh_crate::Size,
                 D: #mh_crate::Digest<S>,
                 Self: From<&'a D>,
             {
@@ -320,7 +321,8 @@ mod tests {
                /// let hash = Code::Sha3_256.digest(b"Hello world!");
                /// println!("{:02x?}", hash);
                /// ```
-               pub fn digest(&self, input: &[u8]) -> Multihash<U32> {
+               pub fn digest(&self, input: &[u8]) -> tiny_multihash::Multihash<U32> {
+                   use tiny_multihash::Hasher;
                    match self {
                        Self::Identity256 => {
                            let digest = tiny_multihash::Identity256::digest(input);
@@ -345,9 +347,9 @@ mod tests {
                /// let hash = Code::multihash_from_digest(&hasher.finalize());
                /// println!("{:02x?}", hash);
                /// ```
-               pub fn multihash_from_digest<'a, S, D>(digest: &'a D) -> Multihash<U32>
+               pub fn multihash_from_digest<'a, S, D>(digest: &'a D) -> tiny_multihash::Multihash<U32>
                where
-                   S: Size,
+                   S: tiny_multihash::Size,
                    D: tiny_multihash::Digest<S>,
                    Self: From<&'a D>,
                {

--- a/derive/src/multihash.rs
+++ b/derive/src/multihash.rs
@@ -81,8 +81,8 @@ impl Hash {
         let code_enum = &params.code_enum;
         let ident = &self.ident;
         quote! {
-           impl From<#digest> for #code_enum {
-               fn from(digest: #digest) -> Self {
+           impl From<&#digest> for #code_enum {
+               fn from(digest: &#digest) -> Self {
                    Self::#ident
                }
            }
@@ -219,14 +219,13 @@ pub fn multihash(s: Structure) -> TokenStream {
             /// let hash = Code::multihash_from_digest(&hasher.finalize());
             /// println!("{:02x?}", hash);
             /// ```
-            pub fn multihash_from_digest<S, D>(digest: &D) -> Multihash<U64>
+            pub fn multihash_from_digest<'a, S, D>(digest: &'a D) -> Multihash<U64>
             where
                 S: Size,
                 D: #mh_crate::Digest<S>,
-                Self: From<D>,
+                Self: From<&'a D>,
             {
-                // TODO vmx 2020-09-22: Don't clone
-                let code = Self::from(digest.clone());
+                let code = Self::from(&digest);
                 #mh_crate::Multihash::wrap(code.into(), &digest.as_ref()).unwrap()
             }
         }
@@ -307,13 +306,13 @@ mod tests {
                /// let hash = Code::multihash_from_digest(&hasher.finalize());
                /// println!("{:02x?}", hash);
                /// ```
-               pub fn multihash_from_digest<S, D>(digest: &D) -> Multihash<U64>
+               pub fn multihash_from_digest<'a, S, D>(digest: &'a D) -> Multihash<U64>
                where
                    S: Size,
                    D: tiny_multihash::Digest<S>,
-                   Self: From<D>,
+                   Self: From<&'a D>,
                {
-                   let code = Self::from(digest.clone());
+                   let code = Self::from(&digest);
                    tiny_multihash::Multihash::wrap(code.into(), &digest.as_ref()).unwrap()
                }
             }
@@ -340,13 +339,13 @@ mod tests {
                 }
             }
 
-            impl From<tiny_multihash::IdentityDigest<U32> > for Code {
-                fn from(digest: tiny_multihash::IdentityDigest<U32>) -> Self {
+            impl From<&tiny_multihash::IdentityDigest<U32> > for Code {
+                fn from(digest: &tiny_multihash::IdentityDigest<U32>) -> Self {
                     Self::Identity256
                 }
             }
-            impl From<tiny_multihash::StrobeDigest<U32> > for Code {
-                fn from(digest: tiny_multihash::StrobeDigest<U32>) -> Self {
+            impl From<&tiny_multihash::StrobeDigest<U32> > for Code {
+                fn from(digest: &tiny_multihash::StrobeDigest<U32>) -> Self {
                     Self::Strobe256
                 }
             }

--- a/examples/custom_table.rs
+++ b/examples/custom_table.rs
@@ -1,15 +1,10 @@
 use std::convert::TryFrom;
 
 use tiny_multihash::derive::Multihash;
-use tiny_multihash::typenum::{U20, U25};
+use tiny_multihash::typenum::{U20, U25, U64};
 use tiny_multihash::{
-    Digest, Error, Hasher, Multihash as DefaultMultihash, MultihashDigest, RawMultihash,
-    Sha2Digest, Sha2_256, StatefulHasher,
+    Digest, Error, Hasher, Multihash, Sha2Digest, Sha2_256, Size, StatefulHasher,
 };
-
-// The Multihash code is independent of whether the hash is truncated or not
-const SHA2_256: u64 = 0x12;
-const BLAKE2B_200: u64 = 0xb219;
 
 // You can implement a custom hasher. This is a SHA2 256-bit hasher that returns a hash that is
 // truncated to 160 bits.
@@ -32,60 +27,35 @@ impl StatefulHasher for Sha2_256Truncated20 {
 }
 
 #[derive(Clone, Debug, Eq, Multihash, PartialEq)]
-pub enum Multihash {
+pub enum Code {
     /// Example for using a custom hasher which returns truncated hashes
-    #[mh(code = SHA2_256, hasher = Sha2_256Truncated20)]
-    Sha2_256Truncated20(tiny_multihash::Sha2Digest<U20>),
+    #[mh(code = 0x12, hasher = Sha2_256Truncated20, digest = tiny_multihash::Sha2Digest<U20>)]
+    Sha2_256Truncated20,
     /// Example for using a hasher with a bit size that is not exported by default
-    #[mh(code = BLAKE2B_200, hasher = tiny_multihash::Blake2bHasher::<U25>)]
-    Blake2b200(tiny_multihash::Blake2bDigest<U25>),
-    /// Example of using a number as code value
-    #[mh(code = 0xb214, hasher = tiny_multihash::Blake2bHasher::<U20>)]
-    ByCode(tiny_multihash::Blake2bDigest<U20>),
+    #[mh(code = 0xb219, hasher = tiny_multihash::Blake2bHasher::<U25>, digest = tiny_multihash::Blake2bDigest<U25>)]
+    Blake2b200,
 }
 
 fn main() {
-    // Create new hashes from some input data
-    let blake_hash = Multihash::new(BLAKE2B_200, b"hello world!").unwrap();
+    // Create new hashes from some input data. This is done through the `Code` enum we derived
+    // Multihash from.
+    let blake_hash = Code::Blake2b200.digest(b"hello world!");
     println!("{:02x?}", blake_hash);
-    // A truncated hash, still has the same Multihash code as a non-truncated one
-    let truncated_sha2_hash = Multihash::new(SHA2_256, b"hello world!").unwrap();
+    let truncated_sha2_hash = Code::Sha2_256Truncated20.digest(b"hello world!");
     println!("{:02x?}", truncated_sha2_hash);
 
     // Sometimes you might not need to hash new data, you just want to get the information about
-    // a Multihash. This is what `RawMultihash` is for.
+    // a Multihash.
     let truncated_sha2_bytes = truncated_sha2_hash.to_bytes();
-    let unknown_hash = RawMultihash::from_bytes(&truncated_sha2_bytes).unwrap();
-    //println!("{:02x?}", unknown_hash);
+    let unknown_hash = Multihash::<U64>::from_bytes(&truncated_sha2_bytes).unwrap();
     println!("SHA2 256-bit hash truncated to 160 bits:");
     println!("  code: {:x?}", unknown_hash.code());
     println!("  size: {}", unknown_hash.size());
     println!("  digest: {:02x?}", unknown_hash.digest());
 
-    // Though you can transform a `RawMultihash` into your custom one if you have something for
-    // the related code specified
-    let truncated_sha2_hash_again: Multihash = unknown_hash.to_mh().unwrap();
-    assert_eq!(truncated_sha2_hash_again, truncated_sha2_hash);
-
-    // Not only the code is checked, but also the Digest size. This way you don't accidentally
-    // work with truncated hashes without knowing.
-    // To try this out we create a usual SHA2 256-bit hash that wasn't truncated
-    let sha2_raw_hash = DefaultMultihash::new(SHA2_256, b"hello world!")
+    // Though you might want to hash something new, with the same hasher that some other Multihash
+    // used.
+    Code::try_from(unknown_hash.code())
         .unwrap()
-        .to_raw()
-        .unwrap();
-    println!("SHA2 256-bit hash:");
-    println!("  code: {:x?}", sha2_raw_hash.code());
-    println!("  size: {}", sha2_raw_hash.size());
-    println!("  digest: {:02x?}", sha2_raw_hash.digest());
-    // Now we try to convert it to a Multihash as part of our custom Multihash table
-    let sha2_hash_error: Result<Multihash, _> = sha2_raw_hash.to_mh();
-    // It errors as we only have defined a truncated SHA2 hash
-    println!("Hash has the wrong size: {:?}", sha2_hash_error);
-    // But it of course works with the default Multihash table
-    let sha2_hash: Result<DefaultMultihash, _> = sha2_raw_hash.to_mh();
-    println!(
-        "The size matches the one of the default Multihash table: {:02x?}",
-        sha2_hash
-    );
+        .digest(b"hashing something new");
 }

--- a/examples/custom_table.rs
+++ b/examples/custom_table.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 use tiny_multihash::derive::Multihash;
 use tiny_multihash::typenum::{U20, U25, U64};
 use tiny_multihash::{
-    Digest, Error, Hasher, Multihash, Sha2Digest, Sha2_256, Size, StatefulHasher,
+    Digest, Error, Hasher, Multihash, MultihashCode, Sha2Digest, Sha2_256, Size, StatefulHasher,
 };
 
 // You can implement a custom hasher. This is a SHA2 256-bit hasher that returns a hash that is

--- a/examples/custom_table.rs
+++ b/examples/custom_table.rs
@@ -27,6 +27,7 @@ impl StatefulHasher for Sha2_256Truncated20 {
 }
 
 #[derive(Clone, Debug, Eq, Multihash, PartialEq)]
+#[mh(max_size = U64)]
 pub enum Code {
     /// Example for using a custom hasher which returns truncated hashes
     #[mh(code = 0x12, hasher = Sha2_256Truncated20, digest = tiny_multihash::Sha2Digest<U20>)]

--- a/examples/custom_table.rs
+++ b/examples/custom_table.rs
@@ -26,7 +26,7 @@ impl StatefulHasher for Sha2_256Truncated20 {
     }
 }
 
-#[derive(Clone, Debug, Eq, Multihash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Multihash, PartialEq)]
 #[mh(max_size = U64)]
 pub enum Code {
     /// Example for using a custom hasher which returns truncated hashes

--- a/src/arb.rs
+++ b/src/arb.rs
@@ -1,7 +1,7 @@
 use quickcheck::{Arbitrary, Gen};
 use rand::seq::SliceRandom;
 
-use crate::{Code, Multihash, U64};
+use crate::{Code, Multihash, MultihashCode, U64};
 
 const HASHES: [Code; 15] = [
     Code::Sha1,

--- a/src/arb.rs
+++ b/src/arb.rs
@@ -1,42 +1,36 @@
 use quickcheck::{Arbitrary, Gen};
 use rand::seq::SliceRandom;
 
-use crate::multihash::MultihashDigest;
-use crate::multihash_impl::{
-    Multihash, BLAKE2B_256, BLAKE2B_512, BLAKE2S_128, BLAKE2S_256, IDENTITY, KECCAK_224,
-    KECCAK_256, KECCAK_384, KECCAK_512, SHA1, SHA2_256, SHA2_512, SHA3_224, SHA3_256, SHA3_384,
-    SHA3_512,
-};
+use crate::{Code, Multihash, U64};
 
-const HASHES: [u64; 16] = [
-    IDENTITY,
-    SHA1,
-    SHA2_256,
-    SHA2_512,
-    SHA3_512,
-    SHA3_384,
-    SHA3_256,
-    SHA3_224,
-    KECCAK_224,
-    KECCAK_256,
-    KECCAK_384,
-    KECCAK_512,
-    BLAKE2B_256,
-    BLAKE2B_512,
-    BLAKE2S_128,
-    BLAKE2S_256,
+const HASHES: [Code; 15] = [
+    Code::Sha1,
+    Code::Sha2_256,
+    Code::Sha2_512,
+    Code::Sha3_224,
+    Code::Sha3_256,
+    Code::Sha3_384,
+    Code::Sha3_512,
+    Code::Keccak224,
+    Code::Keccak256,
+    Code::Keccak384,
+    Code::Keccak512,
+    Code::Blake2b256,
+    Code::Blake2b512,
+    Code::Blake2s128,
+    Code::Blake2s256,
 ];
 
 /// Generates a random valid multihash.
 ///
 /// This is done by encoding a random piece of data.
-impl Arbitrary for Multihash {
+impl Arbitrary for Multihash<U64> {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         let code = *HASHES.choose(g).unwrap();
         let data: Vec<u8> = Arbitrary::arbitrary(g);
         // encoding an actual random piece of data might be better than just choosing
         // random numbers of the appropriate size, since some hash algos might produce
         // a limited set of values
-        Multihash::new(code, &data).unwrap()
+        code.digest(&data)
     }
 }

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -39,31 +39,10 @@ pub trait Digest<S: Size>:
         if digest.len() != S::to_usize() {
             return Err(Error::InvalidSize(digest.len() as _));
         }
-        Ok(Self::fit(digest))
-    }
-
-    /// Extends the digest size to the required size.
-    fn extend(digest: &[u8]) -> Result<Self, Error> {
-        if digest.len() > S::to_usize() {
-            return Err(Error::InvalidSize(digest.len() as _));
-        }
-        Ok(Self::fit(digest))
-    }
-
-    /// Wraps and the digest bytes.
-    fn truncate(digest: &[u8]) -> Result<Self, Error> {
-        if digest.len() < S::to_usize() {
-            return Err(Error::InvalidSize(digest.len() as _));
-        }
-        Ok(Self::fit(digest))
-    }
-
-    /// Fit the digest bytes.
-    fn fit(digest: &[u8]) -> Self {
         let mut array = GenericArray::default();
         let len = digest.len().min(array.len());
         array[..len].copy_from_slice(&digest[..len]);
-        array.into()
+        Ok(array.into())
     }
 
     /// Reads a multihash digest from a byte stream that contains the digest prefixed with the size.

--- a/src/hasher_impl.rs
+++ b/src/hasher_impl.rs
@@ -46,48 +46,6 @@ macro_rules! derive_digest {
             }
         }
 
-        #[cfg(feature = "scale-codec")]
-        impl parity_scale_codec::Encode for $name<$crate::U32> {
-            fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
-                let mut digest = [0; 32];
-                digest.copy_from_slice(self.as_ref());
-                digest.using_encoded(f)
-            }
-        }
-
-        #[cfg(feature = "scale-codec")]
-        impl parity_scale_codec::Decode for $name<$crate::U32> {
-            fn decode<I: parity_scale_codec::Input>(
-                input: &mut I,
-            ) -> Result<Self, parity_scale_codec::Error> {
-                let digest = <[u8; 32]>::decode(input)?;
-                let mut array = GenericArray::default();
-                array.copy_from_slice(&digest[..]);
-                Ok(Self(array))
-            }
-        }
-
-        #[cfg(feature = "scale-codec")]
-        impl parity_scale_codec::Encode for $name<$crate::U64> {
-            fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
-                let mut digest = [0; 64];
-                digest.copy_from_slice(self.as_ref());
-                digest.using_encoded(f)
-            }
-        }
-
-        #[cfg(feature = "scale-codec")]
-        impl parity_scale_codec::Decode for $name<$crate::U64> {
-            fn decode<I: parity_scale_codec::Input>(
-                input: &mut I,
-            ) -> Result<Self, parity_scale_codec::Error> {
-                let digest = <[u8; 64]>::decode(input)?;
-                let mut array = GenericArray::default();
-                array.copy_from_slice(&digest[..]);
-                Ok(Self(array))
-            }
-        }
-
         impl<S: Size> Digest<S> for $name<S> {}
     };
 }

--- a/src/hasher_impl.rs
+++ b/src/hasher_impl.rs
@@ -88,56 +88,6 @@ macro_rules! derive_digest {
             }
         }
 
-        #[cfg(feature = "serde-codec")]
-        impl<SZ: Size> serde::Serialize for $name<SZ> {
-            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-            where
-                S: serde::Serializer,
-            {
-                use serde::ser::SerializeTuple;
-
-                let mut seq = serializer.serialize_tuple(self.0.len())?;
-                for elem in &self.0[..] {
-                    seq.serialize_element(elem)?;
-                }
-                seq.end()
-            }
-        }
-
-        #[cfg(feature = "serde-codec")]
-        impl<'de, S: Size> serde::Deserialize<'de> for $name<S> {
-            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-            where
-                D: serde::Deserializer<'de>,
-            {
-                use core::marker::PhantomData;
-
-                pub struct DigestVisitor<S: Size>(PhantomData<S>);
-
-                impl<'de, S: Size> serde::de::Visitor<'de> for DigestVisitor<S> {
-                    type Value = $name<S>;
-
-                    fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-                        write!(f, "an array of length {}", S::to_u8())
-                    }
-
-                    fn visit_seq<A: serde::de::SeqAccess<'de>>(
-                        self,
-                        mut seq: A,
-                    ) -> Result<Self::Value, A::Error> {
-                        let mut arr = GenericArray::default();
-                        for (i, b) in arr.iter_mut().enumerate() {
-                            *b = seq
-                                .next_element()?
-                                .ok_or_else(|| serde::de::Error::invalid_length(i, &self))?;
-                        }
-                        Ok($name(arr))
-                    }
-                }
-                deserializer.deserialize_tuple(S::to_usize(), DigestVisitor(PhantomData))
-            }
-        }
-
         impl<S: Size> Digest<S> for $name<S> {}
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,9 @@
 #![deny(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(any(test, feature = "test"))]
-mod arb;
+// TODO vmx 2020-09-22 Enable arb again
+//#[cfg(any(test, feature = "test"))]
+//mod arb;
 mod error;
 mod hasher;
 mod hasher_impl;
@@ -45,17 +46,13 @@ pub use crate::error::{Error, Result};
 #[cfg(feature = "std")]
 pub use crate::hasher::WriteHasher;
 pub use crate::hasher::{Digest, Hasher, Size, StatefulHasher};
-pub use crate::multihash::{MultihashDigest, RawMultihash};
+pub use crate::multihash::Multihash;
 pub use generic_array::typenum::{self, U128, U16, U20, U28, U32, U48, U64};
 #[cfg(feature = "derive")]
 pub use tiny_multihash_derive as derive;
 
 #[cfg(feature = "multihash-impl")]
-pub use crate::multihash_impl::{
-    Multihash, BLAKE2B_256, BLAKE2B_512, BLAKE2S_128, BLAKE2S_256, IDENTITY, KECCAK_224,
-    KECCAK_256, KECCAK_384, KECCAK_512, SHA1, SHA2_256, SHA2_512, SHA3_224, SHA3_256, SHA3_384,
-    SHA3_512,
-};
+pub use crate::multihash_impl::Code;
 
 #[cfg(feature = "blake2b")]
 pub use crate::hasher_impl::blake2b::{Blake2b256, Blake2b512, Blake2bDigest, Blake2bHasher};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ pub use crate::error::{Error, Result};
 #[cfg(feature = "std")]
 pub use crate::hasher::WriteHasher;
 pub use crate::hasher::{Digest, Hasher, Size, StatefulHasher};
-pub use crate::multihash::Multihash;
+pub use crate::multihash::{Multihash, MultihashCode};
 pub use generic_array::typenum::{self, U128, U16, U20, U28, U32, U48, U64};
 #[cfg(feature = "derive")]
 pub use tiny_multihash_derive as derive;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,9 +32,8 @@
 #![deny(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-// TODO vmx 2020-09-22 Enable arb again
-//#[cfg(any(test, feature = "test"))]
-//mod arb;
+#[cfg(any(test, feature = "test"))]
+mod arb;
 mod error;
 mod hasher;
 mod hasher_impl;

--- a/src/multihash.rs
+++ b/src/multihash.rs
@@ -29,8 +29,9 @@ use generic_array::GenericArray;
 // TODO vmx 2020-09-22: Make custom codec serialization possible again
 //#[cfg_attr(feature = "scale-codec", derive(parity_scale_codec::Decode))]
 //#[cfg_attr(feature = "scale-codec", derive(parity_scale_codec::Encode))]
-//#[cfg_attr(feature = "serde-codec", derive(serde::Deserialize))]
-//#[cfg_attr(feature = "serde-codec", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde-codec", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde-codec", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde-codec", serde(bound = "S: Size"))]
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Multihash<S: Size> {
     /// The code of the Multihash.
@@ -189,12 +190,12 @@ mod tests {
     //    assert_eq!(mh, mh2);
     //}
     //
-    //#[test]
-    //#[cfg(feature = "serde-codec")]
-    //fn test_serde() {
-    //    let mh = RawMultihash::default();
-    //    let bytes = serde_json::to_string(&mh).unwrap();
-    //    let mh2 = serde_json::from_str(&bytes).unwrap();
-    //    assert_eq!(mh, mh2);
-    //}
+    #[test]
+    #[cfg(feature = "serde-codec")]
+    fn test_serde() {
+        let mh = Multihash::<crate::U32>::default();
+        let bytes = serde_json::to_string(&mh).unwrap();
+        let mh2 = serde_json::from_str(&bytes).unwrap();
+        assert_eq!(mh, mh2);
+    }
 }

--- a/src/multihash.rs
+++ b/src/multihash.rs
@@ -1,88 +1,19 @@
-use crate::error::Error;
-use crate::hasher::Digest;
+use crate::hasher::Size;
+use crate::Error;
 #[cfg(feature = "std")]
 use core::convert::TryInto;
 use core::fmt::Debug;
-
-/// Trait for reading and writhing Multihashes.
-///
-/// It is usually derived from a list of hashers by the [`Multihash` derive].
-///
-/// [`Multihash` derive]: crate::derive
-pub trait MultihashDigest: Clone + Debug + Eq + Send + Sync + 'static {
-    /// Returns the hash of the input.
-    fn new(code: u64, input: &[u8]) -> Result<Self, Error>;
-
-    /// Wraps the digest in a multihash.
-    fn wrap(code: u64, digest: &[u8]) -> Result<Self, Error>;
-
-    /// Returns the code of the multihash.
-    fn code(&self) -> u64;
-
-    /// Returns the actual size of the digest, that will be returned by `digest()`.
-    fn size(&self) -> u8;
-
-    /// Returns the digest.
-    fn digest(&self) -> &[u8];
-
-    /// Reads a multihash from a byte stream.
-    #[cfg(feature = "std")]
-    fn read<R: std::io::Read>(r: R) -> Result<Self, Error>
-    where
-        Self: Sized;
-
-    /// Parses a multihash from a bytes.
-    ///
-    /// You need to make sure the passed in bytes have the correct length. The digest length
-    /// needs to match the `size` value of the multihash.
-    #[cfg(feature = "std")]
-    fn from_bytes(mut bytes: &[u8]) -> Result<Self, Error>
-    where
-        Self: Sized,
-    {
-        let result = Self::read(&mut bytes)?;
-        // There were more bytes supplied than read
-        if !bytes.is_empty() {
-            return Err(Error::InvalidSize(bytes.len().try_into().expect(
-                "Currently the maximum size is 255, therefore always fits into usize",
-            )));
-        }
-
-        Ok(result)
-    }
-
-    /// Writes a multihash to a byte stream.
-    #[cfg(feature = "std")]
-    fn write<W: std::io::Write>(&self, w: W) -> Result<(), Error> {
-        write_multihash(w, self.code(), self.size(), self.digest())
-    }
-
-    /// Returns the bytes of a multihash.
-    #[cfg(feature = "std")]
-    fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = vec![];
-        self.write(&mut bytes)
-            .expect("writing to a vec should never fail");
-        bytes
-    }
-
-    /// Returns the RawMultihash.
-    fn to_raw(&self) -> Result<RawMultihash, Error> {
-        RawMultihash::from_mh(self)
-    }
-}
+use generic_array::GenericArray;
 
 /// A Multihash instance that only supports the basic functionality and no hashing.
 ///
 /// With this Multihash implementation you can operate on Multihashes in a generic way, but
 /// no hasher implementation is associated with the code.
 ///
-/// The maximum size is currently 512 Bit.
-///
 /// # Example
 ///
 /// ```
-/// use tiny_multihash::{MultihashDigest, RawMultihash};
+/// use tiny_multihash::{Multihash, U64};
 ///
 /// const Sha3_256: u64 = 0x16;
 /// let digest_bytes = [
@@ -90,32 +21,39 @@ pub trait MultihashDigest: Clone + Debug + Eq + Send + Sync + 'static {
 ///     0x76, 0x22, 0xf3, 0xca, 0x71, 0xfb, 0xa1, 0xd9, 0x72, 0xfd, 0x94, 0xa3, 0x1c, 0x3b, 0xfb,
 ///     0xf2, 0x4e, 0x39, 0x38,
 /// ];
-/// let mh = RawMultihash::from_bytes(&digest_bytes).unwrap();
+/// let mh = Multihash::<U64>::from_bytes(&digest_bytes).unwrap();
 /// assert_eq!(mh.code(), Sha3_256);
 /// assert_eq!(mh.size(), 32);
 /// assert_eq!(mh.digest(), &digest_bytes[2..]);
 /// ```
-#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
-#[cfg_attr(feature = "scale-codec", derive(parity_scale_codec::Decode))]
-#[cfg_attr(feature = "scale-codec", derive(parity_scale_codec::Encode))]
-#[cfg_attr(feature = "serde-codec", derive(serde::Deserialize))]
-#[cfg_attr(feature = "serde-codec", derive(serde::Serialize))]
-pub struct RawMultihash {
+// TODO vmx 2020-09-22: Make custom codec serialization possible again
+//#[cfg_attr(feature = "scale-codec", derive(parity_scale_codec::Decode))]
+//#[cfg_attr(feature = "scale-codec", derive(parity_scale_codec::Encode))]
+//#[cfg_attr(feature = "serde-codec", derive(serde::Deserialize))]
+//#[cfg_attr(feature = "serde-codec", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct Multihash<S: Size> {
     /// The code of the Multihash.
     code: u64,
     /// The actual size of the digest in bytes (not the allocated size).
     size: u8,
     /// The digest.
-    digest: crate::UnknownDigest<crate::U64>,
+    digest: GenericArray<u8, S>,
 }
 
-impl RawMultihash {
+impl<S: Size> Multihash<S> {
     /// Wraps the digest in a multihash.
-    pub fn wrap(code: u64, digest: &[u8]) -> Result<Self, Error> {
+    pub fn wrap(code: u64, input_digest: &[u8]) -> Result<Self, Error> {
+        if input_digest.len() > S::to_usize() {
+            return Err(Error::InvalidSize(input_digest.len() as _));
+        }
+        let size = input_digest.len();
+        let mut digest = GenericArray::default();
+        digest[..size].copy_from_slice(input_digest);
         Ok(Self {
             code,
-            size: digest.len() as _,
-            digest: Digest::extend(digest)?,
+            size: size as u8,
+            digest,
         })
     }
 
@@ -131,7 +69,7 @@ impl RawMultihash {
 
     /// Returns the digest.
     pub fn digest(&self) -> &[u8] {
-        &self.digest.as_ref()[..self.size as usize]
+        &self.digest[..self.size as usize]
     }
 
     /// Reads a multihash from a byte stream.
@@ -178,21 +116,6 @@ impl RawMultihash {
             .expect("writing to a vec should never fail");
         bytes
     }
-
-    /// From Multihash.
-    pub fn from_mh<MH: MultihashDigest>(mh: &MH) -> Result<Self, Error> {
-        let digest = Digest::extend(mh.digest())?;
-        Ok(Self {
-            code: mh.code(),
-            size: mh.size(),
-            digest,
-        })
-    }
-
-    /// To Multihash.
-    pub fn to_mh<MH: MultihashDigest>(&self) -> Result<MH, Error> {
-        MH::wrap(self.code(), self.digest())
-    }
 }
 
 /// Writes the multihash to a byte stream.
@@ -222,61 +145,56 @@ where
 ///
 /// Currently the maximum size for a digest is 255 bytes.
 #[cfg(feature = "std")]
-pub fn read_multihash<R, S, D>(mut r: R) -> Result<(u64, u8, D), Error>
+pub fn read_multihash<R, S>(mut r: R) -> Result<(u64, u8, GenericArray<u8, S>), Error>
 where
     R: std::io::Read,
-    S: crate::hasher::Size,
-    D: crate::hasher::Digest<S>,
+    S: Size,
 {
-    use generic_array::GenericArray;
     use unsigned_varint::io::read_u64;
 
     let code = read_u64(&mut r)?;
     let size = read_u64(&mut r)?;
 
-    if size > S::to_u64() || size > u8::max_value() as u64 {
+    if size > S::to_u64() || size > u8::MAX as u64 {
         return Err(Error::InvalidSize(size));
     }
 
     let mut digest = GenericArray::default();
     r.read_exact(&mut digest[..size as usize])?;
-    Ok((code, size as u8, D::from(digest)))
+    Ok((code, size as u8, digest))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::hasher::Hasher;
-    use crate::hasher_impl::sha2::Sha2_256;
-    use crate::multihash_impl::Multihash;
+    use crate::multihash_impl::Code;
 
     #[test]
     fn roundtrip() {
-        let digest = Sha2_256::digest(b"hello world");
-        let hash = Multihash::from(digest);
+        let hash = Code::Sha2_256.digest(b"hello world");
         let mut buf = [0u8; 35];
         hash.write(&mut buf[..]).unwrap();
         let hash2 = Multihash::read(&buf[..]).unwrap();
         assert_eq!(hash, hash2);
     }
 
-    #[test]
-    #[cfg(feature = "scale-codec")]
-    fn test_scale() {
-        use parity_scale_codec::{Decode, Encode};
-
-        let mh = RawMultihash::default();
-        let bytes = mh.encode();
-        let mh2: RawMultihash = Decode::decode(&mut &bytes[..]).unwrap();
-        assert_eq!(mh, mh2);
-    }
-
-    #[test]
-    #[cfg(feature = "serde-codec")]
-    fn test_serde() {
-        let mh = RawMultihash::default();
-        let bytes = serde_json::to_string(&mh).unwrap();
-        let mh2 = serde_json::from_str(&bytes).unwrap();
-        assert_eq!(mh, mh2);
-    }
+    //#[test]
+    //#[cfg(feature = "scale-codec")]
+    //fn test_scale() {
+    //    use parity_scale_codec::{Decode, Encode};
+    //
+    //    let mh = RawMultihash::default();
+    //    let bytes = mh.encode();
+    //    let mh2: RawMultihash = Decode::decode(&mut &bytes[..]).unwrap();
+    //    assert_eq!(mh, mh2);
+    //}
+    //
+    //#[test]
+    //#[cfg(feature = "serde-codec")]
+    //fn test_serde() {
+    //    let mh = RawMultihash::default();
+    //    let bytes = serde_json::to_string(&mh).unwrap();
+    //    let mh2 = serde_json::from_str(&bytes).unwrap();
+    //    assert_eq!(mh, mh2);
+    //}
 }

--- a/src/multihash.rs
+++ b/src/multihash.rs
@@ -11,7 +11,9 @@ use generic_array::GenericArray;
 /// It is usually implemented by a custom code table enum that derives the [`Multihash` derive].
 ///
 /// [`Multihash` derive]: crate::derive
-pub trait MultihashCode: TryFrom<u64> + Into<u64> + Send + Sync + 'static {
+pub trait MultihashCode:
+    TryFrom<u64> + Into<u64> + Send + Sync + Unpin + Copy + Eq + Debug + 'static
+{
     /// The maximum size a hash will allocate.
     type MaxSize: Size;
 

--- a/src/multihash_impl.rs
+++ b/src/multihash_impl.rs
@@ -1,5 +1,3 @@
-use crate::hasher::{Hasher, Size};
-use crate::multihash::Multihash;
 use tiny_multihash_derive::Multihash;
 
 /// Default (cryptographically secure) Multihash implementation.

--- a/src/multihash_impl.rs
+++ b/src/multihash_impl.rs
@@ -1,39 +1,9 @@
-use crate::hasher::Hasher;
-use crate::multihash::MultihashDigest;
+use crate::hasher::{Hasher, Size};
+use crate::multihash::Multihash;
 use tiny_multihash_derive::Multihash;
-
-/// Multihash code for Identity.
-pub const IDENTITY: u64 = 0x00;
-/// Multihash code for SHA1.
-pub const SHA1: u64 = 0x11;
-/// Multihash code for SHA2-256.
-pub const SHA2_256: u64 = 0x12;
-/// Multihash code for SHA2-512.
-pub const SHA2_512: u64 = 0x13;
-/// Multihash code for SHA3-224.
-pub const SHA3_224: u64 = 0x17;
-/// Multihash code for SHA3-256.
-pub const SHA3_256: u64 = 0x16;
-/// Multihash code for SHA3-384.
-pub const SHA3_384: u64 = 0x15;
-/// Multihash code for SHA3-512.
-pub const SHA3_512: u64 = 0x14;
-/// Multihash code for KECCAK-224.
-pub const KECCAK_224: u64 = 0x1a;
-/// Multihash code for KECCAK-256.
-pub const KECCAK_256: u64 = 0x1b;
-/// Multihash code for KECCAK-384.
-pub const KECCAK_384: u64 = 0x1c;
-/// Multihash code for KECCAK-512.
-pub const KECCAK_512: u64 = 0x1d;
-/// Multihash code for BLAKE2b-256.
-pub const BLAKE2B_256: u64 = 0xb220;
-/// Multihash code for BLAKE2b-512.
-pub const BLAKE2B_512: u64 = 0xb240;
-/// Multihash code for BLAKE2s-128.
-pub const BLAKE2S_128: u64 = 0xb250;
-/// Multihash code for BLAKE2s-256.
-pub const BLAKE2S_256: u64 = 0xb260;
+// TODO vmx 2020-09-20: make things work without this import (have it directly importet in the
+// derive)
+use crate::U64;
 
 /// Default (cryptographically secure) Multihash implementation.
 ///
@@ -42,49 +12,67 @@ pub const BLAKE2S_256: u64 = 0xb260;
 ///
 /// [`Multihash` derive]: crate::derive
 #[derive(Copy, Clone, Debug, Eq, Multihash, PartialEq)]
-pub enum Multihash {
-    /// Multihash array for hash function.
-    #[mh(code = self::SHA2_256, hasher = crate::Sha2_256)]
-    Sha2_256(crate::Sha2Digest<crate::U32>),
-    /// Multihash array for hash function.
-    #[mh(code = self::SHA2_512, hasher = crate::Sha2_512)]
-    Sha2_512(crate::Sha2Digest<crate::U64>),
-    /// Multihash array for hash function.
-    #[mh(code = self::SHA3_224, hasher = crate::Sha3_224)]
-    Sha3_224(crate::Sha3Digest<crate::U28>),
-    /// Multihash array for hash function.
-    #[mh(code = self::SHA3_256, hasher = crate::Sha3_256)]
-    Sha3_256(crate::Sha3Digest<crate::U32>),
-    /// Multihash array for hash function.
-    #[mh(code = self::SHA3_384, hasher = crate::Sha3_384)]
-    Sha3_384(crate::Sha3Digest<crate::U48>),
-    /// Multihash array for hash function.
-    #[mh(code = self::SHA3_512, hasher = crate::Sha3_512)]
-    Sha3_512(crate::Sha3Digest<crate::U64>),
-    /// Multihash array for hash function.
-    #[mh(code = self::KECCAK_224, hasher = crate::Keccak224)]
-    Keccak224(crate::KeccakDigest<crate::U28>),
-    /// Multihash array for hash function.
-    #[mh(code = self::KECCAK_256, hasher = crate::Keccak256)]
-    Keccak256(crate::KeccakDigest<crate::U32>),
-    /// Multihash array for hash function.
-    #[mh(code = self::KECCAK_384, hasher = crate::Keccak384)]
-    Keccak384(crate::KeccakDigest<crate::U48>),
-    /// Multihash array for hash function.
-    #[mh(code = self::KECCAK_512, hasher = crate::Keccak512)]
-    Keccak512(crate::KeccakDigest<crate::U64>),
-    /// Multihash array for hash function.
-    #[mh(code = self::BLAKE2B_256, hasher = crate::Blake2b256)]
-    Blake2b256(crate::Blake2bDigest<crate::U32>),
-    /// Multihash array for hash function.
-    #[mh(code = self::BLAKE2B_512, hasher = crate::Blake2b512)]
-    Blake2b512(crate::Blake2bDigest<crate::U64>),
-    /// Multihash array for hash function.
-    #[mh(code = self::BLAKE2S_128, hasher = crate::Blake2s128)]
-    Blake2s128(crate::Blake2sDigest<crate::U16>),
-    /// Multihash array for hash function.
-    #[mh(code = self::BLAKE2S_256, hasher = crate::Blake2s256)]
-    Blake2s256(crate::Blake2sDigest<crate::U32>),
+pub enum Code {
+    /// SHA-1 (20-byte hash size)
+    #[cfg(feature = "sha1")]
+    #[mh(code = 0x11, hasher = crate::Sha1, digest = crate::Sha1Digest<crate::U20>)]
+    Sha1,
+    /// SHA-256 (32-byte hash size)
+    #[cfg(feature = "sha2")]
+    #[mh(code = 0x12, hasher = crate::Sha2_256, digest = crate::Sha2Digest<crate::U32>)]
+    Sha2_256,
+    /// SHA-512 (64-byte hash size)
+    #[cfg(feature = "sha2")]
+    #[mh(code = 0x13, hasher = crate::Sha2_512, digest = crate::Sha2Digest<crate::U64>)]
+    Sha2_512,
+    /// SHA3-224 (28-byte hash size)
+    #[cfg(feature = "sha3")]
+    #[mh(code = 0x17, hasher = crate::Sha3_224, digest = crate::Sha3Digest<crate::U28>)]
+    Sha3_224,
+    /// SHA3-256 (32-byte hash size)
+    #[cfg(feature = "sha3")]
+    #[mh(code = 0x16, hasher = crate::Sha3_256, digest = crate::Sha3Digest<crate::U32>)]
+    Sha3_256,
+    /// SHA3-384 (48-byte hash size)
+    #[cfg(feature = "sha3")]
+    #[mh(code = 0x15, hasher = crate::Sha3_384, digest = crate::Sha3Digest<crate::U48>)]
+    Sha3_384,
+    /// SHA3-512 (64-byte hash size)
+    #[cfg(feature = "sha3")]
+    #[mh(code = 0x14, hasher = crate::Sha3_512, digest = crate::Sha3Digest<crate::U64>)]
+    Sha3_512,
+    /// Keccak-224 (28-byte hash size)
+    #[cfg(feature = "sha3")]
+    #[mh(code = 0x1a, hasher = crate::Keccak224, digest = crate::KeccakDigest<crate::U28>)]
+    Keccak224,
+    /// Keccak-256 (32-byte hash size)
+    #[cfg(feature = "sha3")]
+    #[mh(code = 0x1b, hasher = crate::Keccak256, digest = crate::KeccakDigest<crate::U32>)]
+    Keccak256,
+    /// Keccak-384 (48-byte hash size)
+    #[cfg(feature = "sha3")]
+    #[mh(code = 0x1c, hasher = crate::Keccak384, digest = crate::KeccakDigest<crate::U48>)]
+    Keccak384,
+    /// Keccak-512 (64-byte hash size)
+    #[cfg(feature = "sha3")]
+    #[mh(code = 0x1d, hasher = crate::Keccak512, digest = crate::KeccakDigest<crate::U64>)]
+    Keccak512,
+    /// BLAKE2b-256 (32-byte hash size)
+    #[cfg(feature = "blake2b")]
+    #[mh(code = 0xb220, hasher = crate::Blake2b256, digest = crate::Blake2bDigest<crate::U32>)]
+    Blake2b256,
+    /// BLAKE2b-512 (64-byte hash size)
+    #[cfg(feature = "blake2b")]
+    #[mh(code = 0xb240, hasher = crate::Blake2b512, digest = crate::Blake2bDigest<crate::U64>)]
+    Blake2b512,
+    /// BLAKE2s-128 (16-byte hash size)
+    #[cfg(feature = "blake2s")]
+    #[mh(code = 0xb250, hasher = crate::Blake2s128, digest = crate::Blake2sDigest<crate::U16>)]
+    Blake2s128,
+    /// BLAKE2s-256 (32-byte hash size)
+    #[cfg(feature = "blake2s")]
+    #[mh(code = 0xb260, hasher = crate::Blake2s256, digest = crate::Blake2sDigest<crate::U32>)]
+    Blake2s256,
 }
 
 #[cfg(test)]
@@ -92,27 +80,26 @@ mod tests {
     use super::*;
     use crate::hasher::Hasher;
     use crate::hasher_impl::sha3::{Sha3_256, Sha3_512};
-    use crate::multihash::MultihashDigest;
 
     #[test]
     fn test_hasher_256() {
         let digest = Sha3_256::digest(b"hello world");
-        let hash = Multihash::from(digest);
-        let hash2 = Multihash::new(SHA3_256, b"hello world").unwrap();
-        assert_eq!(hash.code(), SHA3_256);
+        let hash = Code::multihash_from_digest(&digest);
+        let hash2 = Code::Sha3_256.digest(b"hello world");
+        assert_eq!(hash.code(), u64::from(Code::Sha3_256));
         assert_eq!(hash.size(), 32);
-        assert_eq!(hash.digest(), digest.as_ref());
+        assert_eq!(hash.digest(), &digest.as_ref()[..]);
         assert_eq!(hash, hash2);
     }
 
     #[test]
     fn test_hasher_512() {
         let digest = Sha3_512::digest(b"hello world");
-        let hash = Multihash::from(digest);
-        let hash2 = Multihash::new(SHA3_512, b"hello world").unwrap();
-        assert_eq!(hash.code(), SHA3_512);
+        let hash = Code::multihash_from_digest(&digest);
+        let hash2 = Code::Sha3_512.digest(b"hello world");
+        assert_eq!(hash.code(), u64::from(Code::Sha3_512));
         assert_eq!(hash.size(), 64);
-        assert_eq!(hash.digest(), digest.as_ref());
+        assert_eq!(hash.digest(), &digest.as_ref()[..]);
         assert_eq!(hash, hash2);
     }
 }

--- a/src/multihash_impl.rs
+++ b/src/multihash_impl.rs
@@ -76,6 +76,7 @@ mod tests {
     use super::*;
     use crate::hasher::Hasher;
     use crate::hasher_impl::sha3::{Sha3_256, Sha3_512};
+    use crate::multihash::MultihashCode;
 
     #[test]
     fn test_hasher_256() {

--- a/src/multihash_impl.rs
+++ b/src/multihash_impl.rs
@@ -1,9 +1,6 @@
 use crate::hasher::{Hasher, Size};
 use crate::multihash::Multihash;
 use tiny_multihash_derive::Multihash;
-// TODO vmx 2020-09-20: make things work without this import (have it directly importet in the
-// derive)
-use crate::U64;
 
 /// Default (cryptographically secure) Multihash implementation.
 ///
@@ -12,6 +9,7 @@ use crate::U64;
 ///
 /// [`Multihash` derive]: crate::derive
 #[derive(Copy, Clone, Debug, Eq, Multihash, PartialEq)]
+#[mh(max_size = crate::U64)]
 pub enum Code {
     /// SHA-1 (20-byte hash size)
     #[cfg(feature = "sha1")]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -3,72 +3,49 @@ use std::io::Cursor;
 use tiny_multihash::{
     derive::Multihash, Blake2b256, Blake2b512, Blake2bDigest, Blake2s128, Blake2s256,
     Blake2sDigest, Digest, Error, Hasher, Identity256, IdentityDigest, Keccak224, Keccak256,
-    Keccak384, Keccak512, KeccakDigest, MultihashDigest, RawMultihash, Sha1, Sha1Digest,
-    Sha2Digest, Sha2_256, Sha2_512, Sha3Digest, Sha3_224, Sha3_256, Sha3_384, Sha3_512,
-    StatefulHasher, Strobe256, Strobe512, StrobeDigest, BLAKE2B_256, BLAKE2B_512, BLAKE2S_128,
-    BLAKE2S_256, IDENTITY, KECCAK_224, KECCAK_256, KECCAK_384, KECCAK_512, SHA1, SHA2_256,
-    SHA2_512, SHA3_224, SHA3_256, SHA3_384, SHA3_512, U16, U20, U28, U32, U48, U64,
+    Keccak384, Keccak512, KeccakDigest, Multihash, Sha1, Sha1Digest, Sha2Digest, Sha2_256,
+    Sha2_512, Sha3Digest, Sha3_224, Sha3_256, Sha3_384, Sha3_512, Size, StatefulHasher, Strobe256,
+    Strobe512, StrobeDigest, U16, U20, U28, U32, U48, U64,
 };
 
-const STROBE_256: u64 = 0x3312e7;
-const STROBE_512: u64 = 0x3312e8;
-
-#[derive(Clone, Debug, Eq, Multihash, PartialEq)]
-pub enum Multihash {
-    /// Multihash array for hash function.
-    #[mh(code = IDENTITY, hasher = Identity256)]
-    Identity(IdentityDigest<U32>),
-    /// Multihash array for hash function.
-    #[mh(code = SHA1, hasher = Sha1)]
-    Sha1(Sha1Digest<U20>),
-    /// Multihash array for hash function.
-    #[mh(code = SHA2_256, hasher = Sha2_256)]
-    Sha2_256(Sha2Digest<U32>),
-    /// Multihash array for hash function.
-    #[mh(code = SHA2_512, hasher = Sha2_512)]
-    Sha2_512(Sha2Digest<U64>),
-    /// Multihash array for hash function.
-    #[mh(code = SHA3_224, hasher = Sha3_224)]
-    Sha3_224(Sha3Digest<U28>),
-    /// Multihash array for hash function.
-    #[mh(code = SHA3_256, hasher = Sha3_256)]
-    Sha3_256(Sha3Digest<U32>),
-    /// Multihash array for hash function.
-    #[mh(code = SHA3_384, hasher = Sha3_384)]
-    Sha3_384(Sha3Digest<U48>),
-    /// Multihash array for hash function.
-    #[mh(code = SHA3_512, hasher = Sha3_512)]
-    Sha3_512(Sha3Digest<U64>),
-    /// Multihash array for hash function.
-    #[mh(code = KECCAK_224, hasher = Keccak224)]
-    Keccak224(KeccakDigest<U28>),
-    /// Multihash array for hash function.
-    #[mh(code = KECCAK_256, hasher = Keccak256)]
-    Keccak256(KeccakDigest<U32>),
-    /// Multihash array for hash function.
-    #[mh(code = KECCAK_384, hasher = Keccak384)]
-    Keccak384(KeccakDigest<U48>),
-    /// Multihash array for hash function.
-    #[mh(code = KECCAK_512, hasher = Keccak512)]
-    Keccak512(KeccakDigest<U64>),
-    /// Multihash array for hash function.
-    #[mh(code = BLAKE2B_256, hasher = Blake2b256)]
-    Blake2b256(Blake2bDigest<U32>),
-    /// Multihash array for hash function.
-    #[mh(code = BLAKE2B_512, hasher = Blake2b512)]
-    Blake2b512(Blake2bDigest<U64>),
-    /// Multihash array for hash function.
-    #[mh(code = BLAKE2S_128, hasher = Blake2s128)]
-    Blake2s128(Blake2sDigest<U16>),
-    /// Multihash array for hash function.
-    #[mh(code = BLAKE2S_256, hasher = Blake2s256)]
-    Blake2s256(Blake2sDigest<U32>),
-    /// Multihash array for hash function.
-    #[mh(code = STROBE_256, hasher = Strobe256)]
-    Strobe256(StrobeDigest<U32>),
-    /// Multihash array for hash function.
-    #[mh(code = STROBE_512, hasher = Strobe512)]
-    Strobe512(StrobeDigest<U64>),
+#[derive(Clone, Copy, Debug, Eq, Multihash, PartialEq)]
+pub enum Code {
+    #[mh(code = 0x00, hasher = Identity256, digest = IdentityDigest<U32>)]
+    Identity,
+    #[mh(code = 0x11, hasher = Sha1, digest = Sha1Digest<U20>)]
+    Sha1,
+    #[mh(code = 0x12, hasher = Sha2_256, digest = Sha2Digest<U32>)]
+    Sha2_256,
+    #[mh(code = 0x13, hasher = Sha2_512, digest = Sha2Digest<U64>)]
+    Sha2_512,
+    #[mh(code = 0x17, hasher = Sha3_224, digest = Sha3Digest<U28>)]
+    Sha3_224,
+    #[mh(code = 0x16, hasher = Sha3_256, digest = Sha3Digest<U32>)]
+    Sha3_256,
+    #[mh(code = 0x15, hasher = Sha3_384, digest = Sha3Digest<U48>)]
+    Sha3_384,
+    #[mh(code = 0x14, hasher = Sha3_512, digest = Sha3Digest<U64>)]
+    Sha3_512,
+    #[mh(code = 0x1a, hasher = Keccak224, digest = KeccakDigest<U28>)]
+    Keccak224,
+    #[mh(code = 0x1b, hasher = Keccak256, digest = KeccakDigest<U32>)]
+    Keccak256,
+    #[mh(code = 0x1c, hasher = Keccak384, digest = KeccakDigest<U48>)]
+    Keccak384,
+    #[mh(code = 0x1d, hasher = Keccak512, digest = KeccakDigest<U64>)]
+    Keccak512,
+    #[mh(code = 0xb220, hasher = Blake2b256, digest = Blake2bDigest<U32>)]
+    Blake2b256,
+    #[mh(code = 0xb240, hasher = Blake2b512, digest = Blake2bDigest<U64>)]
+    Blake2b512,
+    #[mh(code = 0xb250, hasher = Blake2s128, digest = Blake2sDigest<U16>)]
+    Blake2s128,
+    #[mh(code = 0xb260, hasher = Blake2s256, digest = Blake2sDigest<U32>)]
+    Blake2s256,
+    #[mh(code = 0x3312e7, hasher = Strobe256, digest = StrobeDigest<U16>)]
+    Strobe256,
+    #[mh(code = 0x3312e8, hasher = Strobe512, digest = StrobeDigest<U32>)]
+    Strobe512,
 }
 
 /// Helper function to convert a hex-encoded byte array back into a bytearray
@@ -90,23 +67,23 @@ macro_rules! assert_encode {
 
            // From code
            assert_eq!(
-               Multihash::new($code, $data).unwrap().to_bytes(),
+               $code.digest($data).to_bytes(),
                expected,
                "{:?} encodes correctly (from code)", stringify!($alg)
            );
 
            // From digest
            assert_eq!(
-               Multihash::from(<$alg>::digest($data)).to_bytes(),
-               expected,
-               "{:?} encodes correctly (from digest)", stringify!($alg)
+             Code::multihash_from_digest(&<$alg>::digest($data)).to_bytes(),
+             expected,
+             "{:?} encodes correctly (from digest)", stringify!($alg)
            );
 
-           // From hasher
+           // From incremental hashing
            let mut hasher = <$alg>::default();
            hasher.update($data);
            assert_eq!(
-               Multihash::from(hasher.finalize()).to_bytes(),
+               Code::multihash_from_digest(&hasher.finalize()).to_bytes(),
                expected,
                "{:?} encodes correctly (from hasher)", stringify!($alg)
            );
@@ -118,34 +95,35 @@ macro_rules! assert_encode {
 #[test]
 fn multihash_encode() {
     assert_encode! {
-        Identity256, IDENTITY, b"beep boop", "00096265657020626f6f70";
-        Sha1, SHA1, b"beep boop", "11147c8357577f51d4f0a8d393aa1aaafb28863d9421";
-        Sha2_256, SHA2_256, b"helloworld", "1220936a185caaa266bb9cbe981e9e05cb78cd732b0b3280eb944412bb6f8f8f07af";
-        Sha2_256, SHA2_256, b"beep boop", "122090ea688e275d580567325032492b597bc77221c62493e76330b85ddda191ef7c";
-        Sha2_512, SHA2_512, b"hello world", "1340309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f";
-        Sha3_224, SHA3_224, b"hello world", "171Cdfb7f18c77e928bb56faeb2da27291bd790bc1045cde45f3210bb6c5";
-        Sha3_256, SHA3_256, b"hello world", "1620644bcc7e564373040999aac89e7622f3ca71fba1d972fd94a31c3bfbf24e3938";
-        Sha3_384, SHA3_384, b"hello world", "153083bff28dde1b1bf5810071c6643c08e5b05bdb836effd70b403ea8ea0a634dc4997eb1053aa3593f590f9c63630dd90b";
-        Sha3_512, SHA3_512, b"hello world", "1440840006653e9ac9e95117a15c915caab81662918e925de9e004f774ff82d7079a40d4d27b1b372657c61d46d470304c88c788b3a4527ad074d1dccbee5dbaa99a";
-        Keccak224, KECCAK_224, b"hello world", "1A1C25f3ecfebabe99686282f57f5c9e1f18244cfee2813d33f955aae568";
-        Keccak256, KECCAK_256, b"hello world", "1B2047173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad";
-        Keccak384, KECCAK_384, b"hello world", "1C3065fc99339a2a40e99d3c40d695b22f278853ca0f925cde4254bcae5e22ece47e6441f91b6568425adc9d95b0072eb49f";
-        Keccak512, KECCAK_512, b"hello world", "1D403ee2b40047b8060f68c67242175660f4174d0af5c01d47168ec20ed619b0b7c42181f40aa1046f39e2ef9efc6910782a998e0013d172458957957fac9405b67d";
-        Blake2b512, BLAKE2B_512, b"hello world", "c0e40240021ced8799296ceca557832ab941a50b4a11f83478cf141f51f933f653ab9fbcc05a037cddbed06e309bf334942c4e58cdf1a46e237911ccd7fcf9787cbc7fd0";
-        Blake2s256, BLAKE2S_256, b"hello world", "e0e402209aec6806794561107e594b1f6a8a6b0c92a0cba9acf5e5e93cca06f781813b0b";
-        Blake2b256, BLAKE2B_256, b"hello world", "a0e40220256c83b297114d201b30179f3f0ef0cace9783622da5974326b436178aeef610";
-        Blake2s128, BLAKE2S_128, b"hello world", "d0e4021037deae0226c30da2ab424a7b8ee14e83";
+        Identity256, Code::Identity, b"beep boop", "00096265657020626f6f70";
+        Sha1, Code::Sha1, b"beep boop", "11147c8357577f51d4f0a8d393aa1aaafb28863d9421";
+        Sha2_256, Code::Sha2_256, b"helloworld", "1220936a185caaa266bb9cbe981e9e05cb78cd732b0b3280eb944412bb6f8f8f07af";
+        Sha2_256, Code::Sha2_256, b"beep boop", "122090ea688e275d580567325032492b597bc77221c62493e76330b85ddda191ef7c";
+        Sha2_512, Code::Sha2_512, b"hello world", "1340309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f";
+        Sha3_224, Code::Sha3_224, b"hello world", "171Cdfb7f18c77e928bb56faeb2da27291bd790bc1045cde45f3210bb6c5";
+        Sha3_256, Code::Sha3_256, b"hello world", "1620644bcc7e564373040999aac89e7622f3ca71fba1d972fd94a31c3bfbf24e3938";
+        Sha3_384, Code::Sha3_384, b"hello world", "153083bff28dde1b1bf5810071c6643c08e5b05bdb836effd70b403ea8ea0a634dc4997eb1053aa3593f590f9c63630dd90b";
+        Sha3_512, Code::Sha3_512, b"hello world", "1440840006653e9ac9e95117a15c915caab81662918e925de9e004f774ff82d7079a40d4d27b1b372657c61d46d470304c88c788b3a4527ad074d1dccbee5dbaa99a";
+        Keccak224, Code::Keccak224, b"hello world", "1A1C25f3ecfebabe99686282f57f5c9e1f18244cfee2813d33f955aae568";
+        Keccak256, Code::Keccak256, b"hello world", "1B2047173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad";
+        Keccak384, Code::Keccak384, b"hello world", "1C3065fc99339a2a40e99d3c40d695b22f278853ca0f925cde4254bcae5e22ece47e6441f91b6568425adc9d95b0072eb49f";
+        Keccak512, Code::Keccak512, b"hello world", "1D403ee2b40047b8060f68c67242175660f4174d0af5c01d47168ec20ed619b0b7c42181f40aa1046f39e2ef9efc6910782a998e0013d172458957957fac9405b67d";
+        Blake2b512, Code::Blake2b512, b"hello world", "c0e40240021ced8799296ceca557832ab941a50b4a11f83478cf141f51f933f653ab9fbcc05a037cddbed06e309bf334942c4e58cdf1a46e237911ccd7fcf9787cbc7fd0";
+        Blake2s256, Code::Blake2s256, b"hello world", "e0e402209aec6806794561107e594b1f6a8a6b0c92a0cba9acf5e5e93cca06f781813b0b";
+        Blake2b256, Code::Blake2b256, b"hello world", "a0e40220256c83b297114d201b30179f3f0ef0cace9783622da5974326b436178aeef610";
+        Blake2s128, Code::Blake2s128, b"hello world", "d0e4021037deae0226c30da2ab424a7b8ee14e83";
     }
 }
 
 macro_rules! assert_decode {
-    {$( $alg:ident, $hash:expr; )*} => {
+    //{$( $alg:ident, $hash:expr; )*} => {
+    {$( $code:expr, $hash:expr; )*} => {
         $(
             let hash = hex_to_bytes($hash);
             assert_eq!(
-                Multihash::from_bytes(&hash).unwrap().code(),
-                $alg,
-                "{:?} decodes correctly", stringify!($alg)
+                Multihash::<U64>::from_bytes(&hash).unwrap().code(),
+                u64::from($code),
+                "{:?} decodes correctly", stringify!($code)
             );
         )*
     }
@@ -154,42 +132,44 @@ macro_rules! assert_decode {
 #[test]
 fn assert_decode() {
     assert_decode! {
-        IDENTITY, "000a68656c6c6f776f726c64";
-        SHA1, "11147c8357577f51d4f0a8d393aa1aaafb28863d9421";
-        SHA2_256, "1220936a185caaa266bb9cbe981e9e05cb78cd732b0b3280eb944412bb6f8f8f07af";
-        SHA2_256, "122090ea688e275d580567325032492b597bc77221c62493e76330b85ddda191ef7c";
-        SHA2_512, "1340309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f";
-        SHA3_224, "171Cdfb7f18c77e928bb56faeb2da27291bd790bc1045cde45f3210bb6c5";
-        SHA3_256, "1620644bcc7e564373040999aac89e7622f3ca71fba1d972fd94a31c3bfbf24e3938";
-        SHA3_384, "153083bff28dde1b1bf5810071c6643c08e5b05bdb836effd70b403ea8ea0a634dc4997eb1053aa3593f590f9c63630dd90b";
-        SHA3_512, "1440840006653e9ac9e95117a15c915caab81662918e925de9e004f774ff82d7079a40d4d27b1b372657c61d46d470304c88c788b3a4527ad074d1dccbee5dbaa99a";
-        KECCAK_224, "1A1C25f3ecfebabe99686282f57f5c9e1f18244cfee2813d33f955aae568";
-        KECCAK_256, "1B2047173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad";
-        KECCAK_384, "1C3065fc99339a2a40e99d3c40d695b22f278853ca0f925cde4254bcae5e22ece47e6441f91b6568425adc9d95b0072eb49f";
-        KECCAK_512, "1D403ee2b40047b8060f68c67242175660f4174d0af5c01d47168ec20ed619b0b7c42181f40aa1046f39e2ef9efc6910782a998e0013d172458957957fac9405b67d";
-        BLAKE2B_512, "c0e40240021ced8799296ceca557832ab941a50b4a11f83478cf141f51f933f653ab9fbcc05a037cddbed06e309bf334942c4e58cdf1a46e237911ccd7fcf9787cbc7fd0";
-        BLAKE2S_256, "e0e402209aec6806794561107e594b1f6a8a6b0c92a0cba9acf5e5e93cca06f781813b0b";
-        BLAKE2B_256, "a0e40220256c83b297114d201b30179f3f0ef0cace9783622da5974326b436178aeef610";
-        BLAKE2S_128, "d0e4021037deae0226c30da2ab424a7b8ee14e83";
+        Code::Identity, "000a68656c6c6f776f726c64";
+        Code::Sha1, "11147c8357577f51d4f0a8d393aa1aaafb28863d9421";
+        Code::Sha2_256, "1220936a185caaa266bb9cbe981e9e05cb78cd732b0b3280eb944412bb6f8f8f07af";
+        Code::Sha2_256, "122090ea688e275d580567325032492b597bc77221c62493e76330b85ddda191ef7c";
+        Code::Sha2_512, "1340309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f";
+        Code::Sha3_224, "171Cdfb7f18c77e928bb56faeb2da27291bd790bc1045cde45f3210bb6c5";
+        Code::Sha3_256, "1620644bcc7e564373040999aac89e7622f3ca71fba1d972fd94a31c3bfbf24e3938";
+        Code::Sha3_384, "153083bff28dde1b1bf5810071c6643c08e5b05bdb836effd70b403ea8ea0a634dc4997eb1053aa3593f590f9c63630dd90b";
+        Code::Sha3_512, "1440840006653e9ac9e95117a15c915caab81662918e925de9e004f774ff82d7079a40d4d27b1b372657c61d46d470304c88c788b3a4527ad074d1dccbee5dbaa99a";
+        Code::Keccak224, "1A1C25f3ecfebabe99686282f57f5c9e1f18244cfee2813d33f955aae568";
+        Code::Keccak256, "1B2047173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad";
+        Code::Keccak384, "1C3065fc99339a2a40e99d3c40d695b22f278853ca0f925cde4254bcae5e22ece47e6441f91b6568425adc9d95b0072eb49f";
+        Code::Keccak512, "1D403ee2b40047b8060f68c67242175660f4174d0af5c01d47168ec20ed619b0b7c42181f40aa1046f39e2ef9efc6910782a998e0013d172458957957fac9405b67d";
+        Code::Blake2b512, "c0e40240021ced8799296ceca557832ab941a50b4a11f83478cf141f51f933f653ab9fbcc05a037cddbed06e309bf334942c4e58cdf1a46e237911ccd7fcf9787cbc7fd0";
+        Code::Blake2s256, "e0e402209aec6806794561107e594b1f6a8a6b0c92a0cba9acf5e5e93cca06f781813b0b";
+        Code::Blake2b256, "a0e40220256c83b297114d201b30179f3f0ef0cace9783622da5974326b436178aeef610";
+        Code::Blake2s128, "d0e4021037deae0226c30da2ab424a7b8ee14e83";
     }
 }
 
 macro_rules! assert_roundtrip {
-    ($( $alg:ident ),*) => {
+    ($( $code:expr, $alg:ident; )*) => {
         $(
+            // Hashing with one call
             {
-                let hash = Multihash::from($alg::digest(b"helloworld"));
+                let hash = $code.digest(b"helloworld");
                 assert_eq!(
-                    Multihash::from_bytes(&hash.to_bytes()).unwrap().code(),
+                    Multihash::<U64>::from_bytes(&hash.to_bytes()).unwrap().code(),
                     hash.code()
                 );
             }
+            // Hashing incrementally
             {
-                let mut hasher = $alg::default();
+                let mut hasher = <$alg>::default();
                 hasher.update(b"helloworld");
-                let hash = Multihash::from(hasher.finalize());
+                let hash = Code::multihash_from_digest(&hasher.finalize());
                 assert_eq!(
-                    Multihash::from_bytes(&hash.to_bytes()).unwrap().code(),
+                    Multihash::<U64>::from_bytes(&hash.to_bytes()).unwrap().code(),
                     hash.code()
                 );
             }
@@ -201,32 +181,36 @@ macro_rules! assert_roundtrip {
 #[test]
 fn assert_roundtrip() {
     assert_roundtrip!(
-        Identity256,
-        Sha1,
-        Sha2_256,
-        Sha2_512,
-        Sha3_224,
-        Sha3_256,
-        Sha3_384,
-        Sha3_512,
-        Keccak224,
-        Keccak256,
-        Keccak384,
-        Keccak512,
-        Blake2b512,
-        Blake2s256
+        Code::Identity, Identity256;
+        Code::Sha1, Sha1;
+        Code::Sha2_256, Sha2_256;
+        Code::Sha2_512, Sha2_512;
+        Code::Sha3_224, Sha3_224;
+        Code::Sha3_256, Sha3_256;
+        Code::Sha3_384, Sha3_384;
+        Code::Sha3_512, Sha3_512;
+        Code::Keccak224, Keccak224;
+        Code::Keccak256, Keccak256;
+        Code::Keccak384, Keccak384;
+        Code::Keccak512, Keccak512;
+        Code::Blake2b512, Blake2b512;
+        Code::Blake2s256, Blake2s256;
     );
 }
 
-/// Testing the public interface of `MultihashDigest`
-fn multihash_methods(code: u64, prefix: &str, digest_str: &str) {
+/// Testing the public interface of `Multihash` and coversions to it
+fn multihash_methods<H>(code: Code, prefix: &str, digest_str: &str)
+where
+    H: StatefulHasher,
+    Code: From<H::Digest>,
+{
     let digest = hex_to_bytes(digest_str);
     let expected_bytes = hex_to_bytes(&format!("{}{}", prefix, digest_str));
     let mut expected_cursor = Cursor::new(&expected_bytes);
-    let multihash = Multihash::new(code, b"hello world").unwrap();
+    let multihash = code.digest(b"hello world");
 
-    assert_eq!(Multihash::wrap(code, &digest).unwrap(), multihash);
-    assert_eq!(multihash.code(), code);
+    assert_eq!(Multihash::wrap(code.into(), &digest).unwrap(), multihash);
+    assert_eq!(multihash.code(), u64::from(code));
     assert_eq!(multihash.size() as usize, digest.len());
     assert_eq!(multihash.digest(), digest);
     assert_eq!(Multihash::read(&mut expected_cursor).unwrap(), multihash);
@@ -235,76 +219,88 @@ fn multihash_methods(code: u64, prefix: &str, digest_str: &str) {
     multihash.write(&mut written_buf).unwrap();
     assert_eq!(written_buf, expected_bytes);
     assert_eq!(multihash.to_bytes(), expected_bytes);
-    assert_eq!(
-        multihash.to_raw().unwrap(),
-        RawMultihash::from_bytes(&expected_bytes).unwrap()
-    );
+
+    // Test from hasher digest conversion
+    let mut hasher = H::default();
+    hasher.update(b"hello world");
+    let multihash_from_digest = Code::multihash_from_digest(&hasher.finalize());
+    assert_eq!(multihash_from_digest.code(), u64::from(code));
+    assert_eq!(multihash_from_digest.size() as usize, digest.len());
+    assert_eq!(multihash_from_digest.digest(), digest);
 }
 
 #[test]
 fn test_multihash_methods() {
-    multihash_methods(IDENTITY, "000b", "68656c6c6f20776f726c64");
-    multihash_methods(SHA1, "1114", "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed");
-    multihash_methods(
-        SHA2_256,
+    multihash_methods::<Identity256>(Code::Identity, "000b", "68656c6c6f20776f726c64");
+    multihash_methods::<Sha1>(
+        Code::Sha1,
+        "1114",
+        "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
+    );
+    multihash_methods::<Sha2_256>(
+        Code::Sha2_256,
         "1220",
         "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
     );
-    multihash_methods(
-        SHA2_512,
-       "1340",
-       "309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f");
-    multihash_methods(
-        SHA3_224,
+    multihash_methods::<Sha2_512>(
+      Code::Sha2_512,
+     "1340",
+     "309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f");
+    multihash_methods::<Sha3_224>(
+        Code::Sha3_224,
         "171C",
         "dfb7f18c77e928bb56faeb2da27291bd790bc1045cde45f3210bb6c5",
     );
-    multihash_methods(
-        SHA3_256,
+    multihash_methods::<Sha3_256>(
+        Code::Sha3_256,
         "1620",
         "644bcc7e564373040999aac89e7622f3ca71fba1d972fd94a31c3bfbf24e3938",
     );
-    multihash_methods(
-       SHA3_384,
-       "1530",
-       "83bff28dde1b1bf5810071c6643c08e5b05bdb836effd70b403ea8ea0a634dc4997eb1053aa3593f590f9c63630dd90b");
-    multihash_methods(
-       SHA3_512,
-       "1440",
-       "840006653e9ac9e95117a15c915caab81662918e925de9e004f774ff82d7079a40d4d27b1b372657c61d46d470304c88c788b3a4527ad074d1dccbee5dbaa99a");
-    multihash_methods(
-        KECCAK_224,
+    multihash_methods::<Sha3_384>(
+     Code::Sha3_384,
+     "1530",
+     "83bff28dde1b1bf5810071c6643c08e5b05bdb836effd70b403ea8ea0a634dc4997eb1053aa3593f590f9c63630dd90b");
+    multihash_methods::<Sha3_512>(
+     Code::Sha3_512,
+     "1440",
+     "840006653e9ac9e95117a15c915caab81662918e925de9e004f774ff82d7079a40d4d27b1b372657c61d46d470304c88c788b3a4527ad074d1dccbee5dbaa99a");
+    multihash_methods::<Keccak224>(
+        Code::Keccak224,
         "1A1C",
         "25f3ecfebabe99686282f57f5c9e1f18244cfee2813d33f955aae568",
     );
-    multihash_methods(
-        KECCAK_256,
+    multihash_methods::<Keccak256>(
+        Code::Keccak256,
         "1B20",
         "47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad",
     );
-    multihash_methods(
-       KECCAK_384,
-       "1C30",
-       "65fc99339a2a40e99d3c40d695b22f278853ca0f925cde4254bcae5e22ece47e6441f91b6568425adc9d95b0072eb49f");
-    multihash_methods(
-       KECCAK_512,
-       "1D40",
-       "3ee2b40047b8060f68c67242175660f4174d0af5c01d47168ec20ed619b0b7c42181f40aa1046f39e2ef9efc6910782a998e0013d172458957957fac9405b67d");
-    multihash_methods(
-       BLAKE2B_512,
-       "c0e40240",
-       "021ced8799296ceca557832ab941a50b4a11f83478cf141f51f933f653ab9fbcc05a037cddbed06e309bf334942c4e58cdf1a46e237911ccd7fcf9787cbc7fd0");
-    multihash_methods(
-        BLAKE2S_256,
+    multihash_methods::<Keccak384>(
+     Code::Keccak384,
+     "1C30",
+     "65fc99339a2a40e99d3c40d695b22f278853ca0f925cde4254bcae5e22ece47e6441f91b6568425adc9d95b0072eb49f");
+    multihash_methods::<Keccak512>(
+     Code::Keccak512,
+     "1D40",
+     "3ee2b40047b8060f68c67242175660f4174d0af5c01d47168ec20ed619b0b7c42181f40aa1046f39e2ef9efc6910782a998e0013d172458957957fac9405b67d");
+    multihash_methods::<Blake2b512>(
+     Code::Blake2b512,
+     "c0e40240",
+     "021ced8799296ceca557832ab941a50b4a11f83478cf141f51f933f653ab9fbcc05a037cddbed06e309bf334942c4e58cdf1a46e237911ccd7fcf9787cbc7fd0");
+    multihash_methods::<Blake2s256>(
+        Code::Blake2s256,
         "e0e40220",
         "9aec6806794561107e594b1f6a8a6b0c92a0cba9acf5e5e93cca06f781813b0b",
     );
-    multihash_methods(
-        BLAKE2B_256,
+    multihash_methods::<Blake2b256>(
+        Code::Blake2b256,
         "a0e40220",
         "256c83b297114d201b30179f3f0ef0cace9783622da5974326b436178aeef610",
     );
-    multihash_methods(BLAKE2S_128, "d0e40210", "37deae0226c30da2ab424a7b8ee14e83");
+    multihash_methods::<Blake2s128>(
+        Code::Blake2s128,
+        "d0e40210",
+        "37deae0226c30da2ab424a7b8ee14e83",
+    );
 }
 
 #[test]
@@ -318,47 +314,25 @@ fn test_long_identity_hash() {
 #[test]
 fn multihash_errors() {
     assert!(
-        Multihash::from_bytes(&[]).is_err(),
+        Multihash::<U64>::from_bytes(&[]).is_err(),
         "Should error on empty data"
     );
     assert!(
-        Multihash::from_bytes(&[1, 2, 3]).is_err(),
+        Multihash::<U64>::from_bytes(&[1, 2, 3]).is_err(),
         "Should error on invalid multihash"
     );
     assert!(
-        Multihash::from_bytes(&[1, 2, 3]).is_err(),
+        Multihash::<U64>::from_bytes(&[1, 2, 3]).is_err(),
         "Should error on invalid prefix"
     );
     assert!(
-        Multihash::from_bytes(&[0x12, 0x20, 0xff]).is_err(),
+        Multihash::<U64>::from_bytes(&[0x12, 0x20, 0xff]).is_err(),
         "Should error on correct prefix with wrong digest"
     );
     let identity_code: u8 = 0x00;
     let identity_length = 3;
     assert!(
-        Multihash::from_bytes(&[identity_code, identity_length, 1, 2, 3, 4]).is_err(),
+        Multihash::<U64>::from_bytes(&[identity_code, identity_length, 1, 2, 3, 4]).is_err(),
         "Should error on wrong hash length"
     );
-
-    let unsupported_code = 0x04;
-    let hash_length2 = 128;
-    let digest = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
-    let result = Multihash::from_bytes(&[&[unsupported_code, hash_length2], &digest[..]].concat());
-    assert!(
-        match result {
-            Err(Error::UnsupportedCode(0x04)) => true,
-            _ => false,
-        },
-        "Should error on codes that are not part of the code table"
-    );
-}
-
-#[test]
-fn test_raw_multihash() {
-    let digest_hex = "1620644bcc7e564373040999aac89e7622f3ca71fba1d972fd94a31c3bfbf24e3938";
-    let digest_bytes = hex_to_bytes(digest_hex);
-    let mh = RawMultihash::from_bytes(&digest_bytes).unwrap();
-    assert_eq!(mh.code(), SHA3_256);
-    assert_eq!(mh.size(), 32);
-    assert_eq!(mh.digest(), &digest_bytes[2..]);
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -3,9 +3,9 @@ use std::io::Cursor;
 use tiny_multihash::{
     derive::Multihash, Blake2b256, Blake2b512, Blake2bDigest, Blake2s128, Blake2s256,
     Blake2sDigest, Digest, Error, Hasher, Identity256, IdentityDigest, Keccak224, Keccak256,
-    Keccak384, Keccak512, KeccakDigest, Multihash, Sha1, Sha1Digest, Sha2Digest, Sha2_256,
-    Sha2_512, Sha3Digest, Sha3_224, Sha3_256, Sha3_384, Sha3_512, Size, StatefulHasher, Strobe256,
-    Strobe512, StrobeDigest, U16, U20, U28, U32, U48, U64,
+    Keccak384, Keccak512, KeccakDigest, Multihash, MultihashCode, Sha1, Sha1Digest, Sha2Digest,
+    Sha2_256, Sha2_512, Sha3Digest, Sha3_224, Sha3_256, Sha3_384, Sha3_512, Size, StatefulHasher,
+    Strobe256, Strobe512, StrobeDigest, U16, U20, U28, U32, U48, U64,
 };
 
 #[derive(Clone, Copy, Debug, Eq, Multihash, PartialEq)]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -9,6 +9,7 @@ use tiny_multihash::{
 };
 
 #[derive(Clone, Copy, Debug, Eq, Multihash, PartialEq)]
+#[mh(max_size = U64)]
 pub enum Code {
     #[mh(code = 0x00, hasher = Identity256, digest = IdentityDigest<U32>)]
     Identity,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -202,7 +202,7 @@ fn assert_roundtrip() {
 fn multihash_methods<H>(code: Code, prefix: &str, digest_str: &str)
 where
     H: StatefulHasher,
-    Code: From<H::Digest>,
+    Code: for<'a> From<&'a H::Digest>,
 {
     let digest = hex_to_bytes(digest_str);
     let expected_bytes = hex_to_bytes(&format!("{}{}", prefix, digest_str));


### PR DESCRIPTION
Instead of deriving a Multihash enum, derive from a Code enum.

This commit also combines the previously generated `Multihash` enum with
the `RawMultihash` struct. There is now a single `Multihash` type which
is generic over its digest size.

The derived `Code` enum is used for hashing, the `Multihash` only contains
static, general data.

Closes #12, #13.

There a still a few TODOs, but I think it's ready for a review, to see if we want to
do things that way. Things now work more the way they used to work.