### PR TITLE
feat: rename `max_size` derive attribute to `alloc_size`

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -2,17 +2,17 @@
 //!
 //! The digests are stack allocated with a fixed size. That size needs to be big enough to hold any
 //! of the specified hash digests. This cannot be determined reliably on compile-time, hence it
-//! needs to set manually via the `max_size` attribute. Also you might want to set it to bigger
+//! needs to set manually via the `alloc_size` attribute. Also you might want to set it to bigger
 //! sizes then necessarily needed for backwards/forward compatibility.
 //!
-//! If you set `#mh(max_size = …)` to a too low value, you will get compiler errors. Please note
+//! If you set `#mh(alloc_size = …)` to a too low value, you will get compiler errors. Please note
 //! the the sizes are checked only on a syntactic level and *not* on the type level. This means
 //! that digest need to have a size generic, which is a valid `typenum`, for example `U32` or
 //! `generic_array::typenum::U64`.
 //!
-//! You can disable those compiler errors with setting the `no_max_size_errors` attribute. This
+//! You can disable those compiler errors with setting the `no_alloc_size_errors` attribute. This
 //! can be useful if you e.g. have specified type aliases for your hash digests and you are sure
-//! you use the correct value for `max_size`.
+//! you use the correct value for `alloc_size`.
 //!
 //! # Example
 //!
@@ -21,7 +21,7 @@
 //! use tiny_multihash::{U32, U64, MultihashCode};
 //!
 //! #[derive(Clone, Copy, Debug, Eq, Multihash, PartialEq)]
-//! #[mh(max_size = U64)]
+//! #[mh(alloc_size = U64)]
 //! pub enum Code {
 //!     #[mh(code = 0x01, hasher = tiny_multihash::Sha2_256, digest = tiny_multihash::Sha2Digest<U32>)]
 //!     Foo,

--- a/examples/custom_table.rs
+++ b/examples/custom_table.rs
@@ -27,7 +27,7 @@ impl StatefulHasher for Sha2_256Truncated20 {
 }
 
 #[derive(Clone, Copy, Debug, Eq, Multihash, PartialEq)]
-#[mh(max_size = U64)]
+#[mh(alloc_size = U64)]
 pub enum Code {
     /// Example for using a custom hasher which returns truncated hashes
     #[mh(code = 0x12, hasher = Sha2_256Truncated20, digest = tiny_multihash::Sha2Digest<U20>)]

--- a/src/multihash.rs
+++ b/src/multihash.rs
@@ -15,7 +15,7 @@ pub trait MultihashCode:
     TryFrom<u64> + Into<u64> + Send + Sync + Unpin + Copy + Eq + Debug + 'static
 {
     /// The maximum size a hash will allocate.
-    type MaxSize: Size;
+    type AllocSize: Size;
 
     /// Calculate the hash of some input data.
     ///
@@ -28,7 +28,7 @@ pub trait MultihashCode:
     /// let hash = Code::Sha3_256.digest(b"Hello world!");
     /// println!("{:02x?}", hash);
     /// ```
-    fn digest(&self, input: &[u8]) -> Multihash<Self::MaxSize>;
+    fn digest(&self, input: &[u8]) -> Multihash<Self::AllocSize>;
 
     /// Create a multihash from an existing [`Digest`].
     ///
@@ -42,7 +42,7 @@ pub trait MultihashCode:
     /// let hash = Code::multihash_from_digest(&hasher.finalize());
     /// println!("{:02x?}", hash);
     /// ```
-    fn multihash_from_digest<'a, S, D>(digest: &'a D) -> Multihash<Self::MaxSize>
+    fn multihash_from_digest<'a, S, D>(digest: &'a D) -> Multihash<Self::AllocSize>
     where
         S: Size,
         D: Digest<S>,

--- a/src/multihash_impl.rs
+++ b/src/multihash_impl.rs
@@ -7,7 +7,7 @@ use tiny_multihash_derive::Multihash;
 ///
 /// [`Multihash` derive]: crate::derive
 #[derive(Copy, Clone, Debug, Eq, Multihash, PartialEq)]
-#[mh(max_size = crate::U64)]
+#[mh(alloc_size = crate::U64)]
 pub enum Code {
     /// SHA-1 (20-byte hash size)
     #[cfg(feature = "sha1")]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -9,7 +9,7 @@ use tiny_multihash::{
 };
 
 #[derive(Clone, Copy, Debug, Eq, Multihash, PartialEq)]
-#[mh(max_size = U64)]
+#[mh(alloc_size = U64)]
 pub enum Code {
     #[mh(code = 0x00, hasher = Identity256, digest = IdentityDigest<U32>)]
     Identity,


### PR DESCRIPTION
I originally choose the name `max_size` to give an indication what the user
should do with that value. Now that we have compile-time error messages I
think it makes sense to rename it to something that expresses more closely
what it really is about. It's about how many bytes are allocated.